### PR TITLE
Fix handling of params bound with SQL_VARBINARY type

### DIFF
--- a/Pg.xs
+++ b/Pg.xs
@@ -272,7 +272,7 @@ quote(dbh, to_quote_sv, type_sv=Nullsv)
 			}
 
 			/* At this point, type_info points to a valid struct, one way or another */
-			utf8 = imp_dbh->client_encoding_utf8 && PG_BYTEA != type_info->type_id;
+			utf8 = imp_dbh->client_encoding_utf8 && !pg_type_is_binary(type_info);
 
 			if (SvMAGICAL(to_quote_sv))
 				(void)mg_get(to_quote_sv);

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -199,6 +199,8 @@ SV * pg_db_pg_notifies (SV *dbh, imp_dbh_t *imp_dbh);
 
 SV * pg_rightgraded_sv(pTHX_ SV *input, bool utf8);
 
+bool pg_type_is_binary(const sql_type_info_t * const type_info);
+
 SV * pg_stringify_array(SV * input, const char * array_delim, int server_version, bool utf8);
 
 int pg_quickexec (SV *dbh, const char *sql, const int asyncflag);

--- a/t/06bytea.t
+++ b/t/06bytea.t
@@ -17,7 +17,7 @@ my $dbh = connect_database();
 if (! $dbh) {
 	plan skip_all => 'Connection to database failed, cannot continue testing';
 }
-plan tests => 16;
+plan tests => 46;
 
 isnt ($dbh, undef, 'Connect to database for bytea testing');
 
@@ -26,49 +26,61 @@ if ($pgversion >= 80100) {
 	$dbh->do('SET escape_string_warning = false');
 }
 
-my ($sth, $t);
-
-$sth = $dbh->prepare(q{INSERT INTO dbd_pg_test (id,bytetest,bytearray,testarray2) VALUES (?,?,'{1,2,3}','{5,6,7}')});
-
-$t='bytea insert test with string containing null and backslashes';
-$sth->bind_param(1, undef, { pg_type => PG_INT4 });
-$sth->bind_param(2, undef, { pg_type => PG_BYTEA });
-ok ($sth->execute(400, 'aa\\bb\\cc\\\0dd\\'), $t);
-
-$t='bytea insert test with string containing a single quote';
-ok ($sth->execute(401, '\''), $t);
-
-$t='bytea (second) insert test with string containing a single quote';
-ok ($sth->execute(402, '\''), $t);
-
-my ($binary_in, $binary_out);
-$t='store binary data in BYTEA column';
-for(my $i=0; $i<256; $i++) { $binary_out .= chr($i); }
-$sth->{pg_server_prepare} = 0;
-ok ($sth->execute(403, $binary_out), $t);
-$sth->{pg_server_prepare} = 1;
-ok ($sth->execute(404, $binary_out), $t);
-
-if ($pgversion < 90000) {
-    test_outputs(undef);
-    SKIP: { skip 'No BYTEA output format setting before 9.0', 5 }
+foreach my $type_str ('SQL_VARBINARY', '{ TYPE => SQL_VARBINARY }', '{ pg_type => PG_BYTEA }') {
+    my $type = eval $type_str or die $@;
+    test_inserts($type, $type_str);
+    if ($pgversion < 90000) {
+        test_outputs($type, $type_str, undef);
+        SKIP: { skip 'No BYTEA output format setting before 9.0', 5 }
+    }
+    else {
+        test_outputs($type, $type_str, $_) for qw(hex escape);
+    }
+    $dbh->do('delete from dbd_pg_test');
 }
-else {
-    test_outputs($_) for qw(hex escape);
-}
-
-$sth->finish();
 
 cleanup_database($dbh,'test');
 $dbh->disconnect();
 
+my ($t, $binary_out);
+
+sub test_inserts {
+    my $type = shift;
+    my $type_str = shift;
+
+    my $sth = $dbh->prepare(q{INSERT INTO dbd_pg_test (id,bytetest,bytearray,testarray2) VALUES (?,?,'{1,2,3}','{5,6,7}')});
+
+    $t="bytea insert test with string containing null and backslashes (type: $type_str)";
+    $sth->bind_param(1, undef, { pg_type => PG_INT4 });
+    $sth->bind_param(2, undef, $type);
+    ok ($sth->execute(400, 'aa\\bb\\cc\\\0dd\\'), $t);
+
+    $t='bytea insert test with string containing a single quote';
+    ok ($sth->execute(401, '\''), $t);
+
+    $t='bytea (second) insert test with string containing a single quote';
+    ok ($sth->execute(402, '\''), $t);
+
+    $binary_out = '';
+    $t='store binary data in BYTEA column';
+    for (my $i=0; $i<256; $i++) {
+        $binary_out .= chr($i);
+    }
+    $sth->{pg_server_prepare} = 0;
+    ok ($sth->execute(403, $binary_out), $t);
+    $sth->{pg_server_prepare} = 1;
+    ok ($sth->execute(404, $binary_out), $t);
+}
+
 sub test_outputs {
+    my $type = shift;
+    my $type_str = shift;
     my $output = shift;
     $dbh->do(qq{SET bytea_output = '$output'}) if $output;
 
     $t='Received correct text from BYTEA column with backslashes';
     $t.=" ($output output)" if $output;
-    $sth = $dbh->prepare(q{SELECT bytetest FROM dbd_pg_test WHERE id=?});
+    my $sth = $dbh->prepare(q{SELECT bytetest FROM dbd_pg_test WHERE id=?});
     $sth->execute(400);
     my $byte = $sth->fetchall_arrayref()->[0][0];
     is ($byte, 'aa\bb\cc\\\0dd\\', $t);
@@ -82,7 +94,7 @@ sub test_outputs {
     $t='Ensure proper handling of high bit characters';
     $t.=" ($output output)" if $output;
     $sth->execute(403);
-    ($binary_in) = $sth->fetchrow_array();
+    my ($binary_in) = $sth->fetchrow_array();
     cmp_ok ($binary_in, 'eq', $binary_out, $t);
     $sth->execute(404);
     ($binary_in) = $sth->fetchrow_array();
@@ -91,9 +103,9 @@ sub test_outputs {
     $t='quote properly handles bytea strings';
     $t.=" ($output output)" if $output;
     my $string = "abc\123\\def\0ghi";
-    my $result = $dbh->quote($string, { pg_type => PG_BYTEA });
+    my $result = $dbh->quote($string, $type);
     my $E = $pgversion >= 80100 ? q{E} : q{};
     my $expected = qq{${E}'abc\123\\\\\\\\def\\\\000ghi'};
-    is ($result, $expected, $t);
-	return;
+    is ($result, $expected, "$t (type: $type_str)");
+    return;
 }


### PR DESCRIPTION
`$sth->{TYPE}` returns `SQL_VARBINARY` for `bytea` columns, so make sure we treat it the same as `PG_BYTEA`, to avoid breaking generic code that uses the returned types when binding parameters.

Thanks to @tux for reporting the bug.
