### PR TITLE
Allow '%' again for the type in table_info() and thus tables()

### DIFF
--- a/Pg.pm
+++ b/Pg.pm
@@ -1135,7 +1135,7 @@ use 5.008001;
                  ORDER BY "TABLE_TYPE", "TABLE_CAT", "TABLE_SCHEM", "TABLE_NAME"
                 };
 
-            if (defined($type) and length($type)) {
+            if (defined($type) and length($type) and $type ne '%') {
                 my $type_restrict = join ', ' =>
                                       map { $dbh->quote($_) unless /^'/ }
                                         grep {length}

--- a/t/03dbmethod.t
+++ b/t/03dbmethod.t
@@ -26,7 +26,7 @@ my $dbh = connect_database();
 if (! $dbh) {
 	plan skip_all => 'Connection to database failed, cannot continue testing';
 }
-plan tests => 545;
+plan tests => 547;
 
 isnt ($dbh, undef, 'Connect to database for database handle method testing');
 
@@ -483,9 +483,14 @@ is ($dbh->get_info(25), 'N', $t);
 # Test of the "table_info" database handle method
 #
 
-$t='DB handle method "table_info" works when called with undef arguments';
+$t='DB handle method "table_info" works when called with empty arguments';
 $sth = $dbh->table_info('', '', 'dbd_pg_test', '');
 my $number = $sth->rows();
+ok ($number, $t);
+
+$t='DB handle method "table_info" works when called with \'%\' arguments';
+$sth = $dbh->table_info('%', '%', 'dbd_pg_test', '%');
+$number = $sth->rows();
 ok ($number, $t);
 
 # Check required minimum fields
@@ -1178,6 +1183,10 @@ like ($result[0], qr/dbd_pg_test/, $t);
 $t='DB handle method "tables" works with a "pg_noprefix" attribute';
 @result = $dbh->tables('', '', 'dbd_pg_test', '', {pg_noprefix => 1});
 is ($result[0], 'dbd_pg_test', $t);
+
+$t='DB handle method "tables" works with type=\'%\'';
+@result = $dbh->tables('', '', 'dbd_pg_test', '%');
+like ($result[0], qr/dbd_pg_test/, $t);
 
 #
 # Test of the "type_info_all" database handle method


### PR DESCRIPTION
It's not documented or tested in DBI, but it used to work until
DBD::Pg 3.4.0, and the change broke DBIx::Class::Schema::Loader, which
uses type='%'.

I'll separately make DBIx::Class::Schema::Loader be standad-compliant and use
undef instead of '%', but it's worth not breaking users of older versions.
