### PR TITLE
Fix date in Changes file

### DIFF
--- a/Changes
+++ b/Changes
@@ -8,7 +8,7 @@ Version 3.4.3
     [Dagfinn Ilmari Mannsåker <ilmari@ilmari.org>]
 
 
-Version 3.4.2  Released September 25, 2015 (git commit 61440e1f4ccb6c293c5838676da1942e0df67271)
+Version 3.4.2  Released September 25, 2014 (git commit 61440e1f4ccb6c293c5838676da1942e0df67271)
 
   - Fix bug where single-quoted type arguments to the table_info()
     method were causing a SQL error.


### PR DESCRIPTION
I was surprised to read v3.4.2 came out in the future, but was reassured when search.cpan.org told me that it was in fact uploaded on 25th September 2014. I thought I'd better check, just in case.
