### PR TITLE
Mortalise destringifed arrayref before sv_setsv()

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3648,7 +3648,7 @@ AV * dbd_st_fetch (SV * sth, imp_sth_t * imp_sth)
 			if (type_info
 				&& 0 == strncmp(type_info->arrayout, "array", 5)
 				&& imp_dbh->expand_array) {
-				sv_setsv(sv, pg_destringify_array(aTHX_ imp_dbh, value, type_info));
+				sv_setsv(sv, sv_2mortal(pg_destringify_array(aTHX_ imp_dbh, value, type_info)));
 			}
 			else {
 				if (type_info) {


### PR DESCRIPTION
sv_setsv copies the reference, so we need to make sure the original one
gets freed and we don't leak the array

This stops the leak reported by `testme.tmp.pl`
