### PR TITLE
Fix client_encoding detection on pre-9.1 servers

### DIFF
--- a/t/12placeholders.t
+++ b/t/12placeholders.t
@@ -657,8 +657,8 @@ for my $char (qw{0 9 A Z a z}) { ## six letters
 
 SKIP: {
 	my $server_encoding = $dbh->selectrow_array('SHOW server_encoding');
-	skip "Cannot test non-ascii dollar quotes with server_encoding='$server_encoding' (need UTF8)", 3,
-		unless $server_encoding =~ /UTF8/;
+	skip "Cannot test non-ascii dollar quotes with server_encoding='$server_encoding' (need UTF8 or SQL_ASCII)", 3,
+		unless $server_encoding =~ /\A(?:UTF8|SQL_ASCII)\z/;
 
 	for my $ident (qq{\x{5317}}, qq{abc\x{5317}}, qq{_cde\x{5317}}) { ## hi-bit chars
 		eval {

--- a/t/30unicode.t
+++ b/t/30unicode.t
@@ -58,7 +58,6 @@ foreach (
 my %ranges = (
     UTF8 => qr/.*/,
     LATIN1 => qr/\A(?:ascii|latin 1 range)\z/,
-    SQL_ASCII => qr/nada/,
 );
 
 foreach (@tests) {


### PR DESCRIPTION
Before 9.1 the `client_encoding` provided in the connection parameter was
not normalised, so we need to do that ourselves.

This fixes the tests on `SQL_ASCII` databases, as well, so we can revert
the commits that disabled them (1f3ed13 and 53df98c).