### PR TITLE
Fail gracefully on bad UTF-8.

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2938,8 +2938,11 @@ SV * pg_downgraded_sv(pTHX_ SV *input) {
 	for(end = p + len; p != end; p++) {
 		if(*p & 0x80) {
 			SV *output = sv_mortalcopy(input);
-			sv_utf8_downgrade(output, DBDPG_FALSE);
-			return output;
+			if (!sv_utf8_downgrade(output, DBDPG_TRUE)) {
+				return input;
+			} else {
+				return output;
+			}
 		}
 	}
 	return input;


### PR DESCRIPTION
(an updated version, missed one change)

For some reason it's possible to get an invalid UTF8 input in downgrade,
which leads to a very weird stop of processing and errors. The problem
was observed on Request Tracker 4.2.8 with emails with utf8-encoded subject
lines.

This seems like a really hacky fix, and the issue might be somewhere else
on the stack, like some kind of a failure to mark a specific string as UTF-8,
but I have no idea how to track that down.
