### PR TITLE
Support binary COPY format

### DIFF
--- a/Changes
+++ b/Changes
@@ -49,6 +49,9 @@ Version 3.5.9_1 (beta for 3.6.0)
   - Silence warnings in t/02attribs.t and t/04misc.t
     [Dagfinn Ilmari Mannsåker]
 
+  - Fix UTF8 flag handling in pg_(get|put)copydata
+    [Dagfinn Ilmari Mannsåker]
+
   - Switched canonical repo to git://github.com/bucardo/dbdpg.git
 
 

--- a/Changes
+++ b/Changes
@@ -52,6 +52,9 @@ Version 3.5.9_1 (beta for 3.6.0)
   - Fix UTF8 flag handling in pg_(get|put)copydata
     [Dagfinn Ilmari Mannsåker]
 
+  - Support binary COPY format
+    [Dagfinn Ilmari Mannsåker]
+
   - Switched canonical repo to git://github.com/bucardo/dbdpg.git
 
 

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -21,6 +21,7 @@ struct imp_dbh_st {
 	int     pid_number;        /* prefixed before prepare_number */
 	int     prepare_number;    /* internal prepared statement name modifier */
 	int     copystate;         /* 0=none PGRES_COPY_IN PGRES_COPY_OUT */
+	bool    copybinary;        /* whether the copy is in binary format */
 	int     pg_errorlevel;     /* PQsetErrorVerbosity. Set by user, defaults to 1 */
 	int     server_prepare;    /* do we want to use PQexecPrepared? 0=no 1=yes 2=smart. Can be changed by user */
 	int     switch_prepared;   /* how many executes until we switch to PQexecPrepared */


### PR DESCRIPTION
- Use the length returned by PQgetCopyData when storing it in the SV
- Clear the UTF-8 flag, since it's binary data.

Also make sure UTF8 flag is correct in pg_getcopydata in non-binary mode. We're replacing the contents of an existing SV, so make sure the UTF8 flag is set correctly regardless of what it was before.
