### PR TITLE
adjust COPY functions to handle COPY_BOTH mode

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4076,7 +4076,7 @@ int pg_db_putline (SV * dbh, SV * svbuf)
 	if (TSTART_slow) TRC(DBILOGFP, "%sBegin pg_db_putline\n", THEADER_slow);
 
 	/* We must be in COPY IN state */
-	if (PGRES_COPY_IN != imp_dbh->copystate || PGRES_COPY_BOTH != imp_dbh->copystate)
+	if (PGRES_COPY_IN != imp_dbh->copystate && PGRES_COPY_BOTH != imp_dbh->copystate)
 		croak("pg_putline can only be called directly after issuing a COPY FROM command\n");
 
 	if (!svbuf || !SvOK(svbuf))
@@ -4120,7 +4120,7 @@ int pg_db_getline (SV * dbh, SV * svbuf, int length)
 	tempbuf = NULL;
 
 	/* We must be in COPY OUT state */
-	if (PGRES_COPY_OUT != imp_dbh->copystate || PGRES_COPY_BOTH != imp_dbh->copystate)
+	if (PGRES_COPY_OUT != imp_dbh->copystate && PGRES_COPY_BOTH != imp_dbh->copystate)
 		croak("pg_getline can only be called directly after issuing a COPY TO command\n");
 
 	length = 0; /* Make compilers happy */
@@ -4163,7 +4163,7 @@ int pg_db_getcopydata (SV * dbh, SV * dataline, int async)
 	if (TSTART_slow) TRC(DBILOGFP, "%sBegin pg_db_getcopydata\n", THEADER_slow);
 
 	/* We must be in COPY OUT state */
-	if (PGRES_COPY_OUT != imp_dbh->copystate || PGRES_COPY_BOTH != imp_dbh->copystate)
+	if (PGRES_COPY_OUT != imp_dbh->copystate && PGRES_COPY_BOTH != imp_dbh->copystate)
 		croak("pg_getcopydata can only be called directly after issuing a COPY TO command\n");
 
 	tempbuf = NULL;
@@ -4235,7 +4235,7 @@ int pg_db_putcopydata (SV * dbh, SV * dataline)
 	if (TSTART_slow) TRC(DBILOGFP, "%sBegin pg_db_putcopydata\n", THEADER_slow);
 
 	/* We must be in COPY IN state */
-	if (PGRES_COPY_IN != imp_dbh->copystate || PGRES_COPY_BOTH != imp_dbh->copystate)
+	if (PGRES_COPY_IN != imp_dbh->copystate && PGRES_COPY_BOTH != imp_dbh->copystate)
 		croak("pg_putcopydata can only be called directly after issuing a COPY FROM command\n");
 
 	if (imp_dbh->pg_utf8_flag && !imp_dbh->copybinary)

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3633,10 +3633,10 @@ long dbd_st_execute (SV * sth, imp_sth_t * imp_sth)
 			return 0;
 		}
 	}
-	else if (PGRES_COPY_OUT == status || PGRES_COPY_IN == status) {
+	else if (PGRES_COPY_OUT == status || PGRES_COPY_IN == status || PGRES_COPY_BOTH == status) {
 		if (TRACE5_slow)
 			TRC(DBILOGFP, "%sStatus was PGRES_COPY_%s\n",
-				THEADER_slow, PGRES_COPY_OUT == status ? "OUT" : "IN");
+				THEADER_slow, PGRES_COPY_OUT == status ? "OUT" : PGRES_COPY_IN == status ? "IN" : "BOTH");
 		/* Copy Out/In data transfer in progress */
 		imp_dbh->copystate = status;
 		imp_dbh->copybinary = PQbinaryTuples(imp_sth->result);
@@ -4076,7 +4076,7 @@ int pg_db_putline (SV * dbh, SV * svbuf)
 	if (TSTART_slow) TRC(DBILOGFP, "%sBegin pg_db_putline\n", THEADER_slow);
 
 	/* We must be in COPY IN state */
-	if (PGRES_COPY_IN != imp_dbh->copystate)
+	if (PGRES_COPY_IN != imp_dbh->copystate || PGRES_COPY_BOTH != imp_dbh->copystate)
 		croak("pg_putline can only be called directly after issuing a COPY FROM command\n");
 
 	if (!svbuf || !SvOK(svbuf))
@@ -4120,7 +4120,7 @@ int pg_db_getline (SV * dbh, SV * svbuf, int length)
 	tempbuf = NULL;
 
 	/* We must be in COPY OUT state */
-	if (PGRES_COPY_OUT != imp_dbh->copystate)
+	if (PGRES_COPY_OUT != imp_dbh->copystate || PGRES_COPY_BOTH != imp_dbh->copystate)
 		croak("pg_getline can only be called directly after issuing a COPY TO command\n");
 
 	length = 0; /* Make compilers happy */
@@ -4163,7 +4163,7 @@ int pg_db_getcopydata (SV * dbh, SV * dataline, int async)
 	if (TSTART_slow) TRC(DBILOGFP, "%sBegin pg_db_getcopydata\n", THEADER_slow);
 
 	/* We must be in COPY OUT state */
-	if (PGRES_COPY_OUT != imp_dbh->copystate)
+	if (PGRES_COPY_OUT != imp_dbh->copystate || PGRES_COPY_BOTH != imp_dbh->copystate)
 		croak("pg_getcopydata can only be called directly after issuing a COPY TO command\n");
 
 	tempbuf = NULL;
@@ -4235,7 +4235,7 @@ int pg_db_putcopydata (SV * dbh, SV * dataline)
 	if (TSTART_slow) TRC(DBILOGFP, "%sBegin pg_db_putcopydata\n", THEADER_slow);
 
 	/* We must be in COPY IN state */
-	if (PGRES_COPY_IN != imp_dbh->copystate)
+	if (PGRES_COPY_IN != imp_dbh->copystate || PGRES_COPY_BOTH != imp_dbh->copystate)
 		croak("pg_putcopydata can only be called directly after issuing a COPY FROM command\n");
 
 	if (imp_dbh->pg_utf8_flag && !imp_dbh->copybinary)
@@ -4267,7 +4267,7 @@ int pg_db_putcopydata (SV * dbh, SV * dataline)
 int pg_db_putcopyend (SV * dbh)
 {
 
-	/* If in COPY_IN mode, terminate the COPYing */
+	/* If in COPY_IN or COPY_BOTH mode, terminate the COPYing */
 	/* Returns 1 on success, otherwise 0 (plus a probably warning/error) */
 
 	dTHX;
@@ -4288,7 +4288,7 @@ int pg_db_putcopyend (SV * dbh)
 		return 0;
 	}
 
-	/* Must be PGRES_COPY_IN at this point */
+	/* Must be PGRES_COPY_IN or PGRES_COPY_BOTH at this point */
 
 	TRACE_PQPUTCOPYEND;
 	copystatus = PQputCopyEnd(imp_dbh->conn, NULL);

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4247,6 +4247,12 @@ int pg_db_putcopydata (SV * dbh, SV * dataline)
 	copystatus = PQputCopyData(imp_dbh->conn, copydata, copylen);
 
 	if (1 == copystatus) {
+		if (PGRES_COPY_BOTH == imp_dbh->copystate && PQflush(imp_dbh->conn)) {
+			_fatal_sqlstate(aTHX_ imp_dbh);
+
+			TRACE_PQERRORMESSAGE;
+			pg_error(aTHX_ dbh, PGRES_FATAL_ERROR, PQerrorMessage(imp_dbh->conn));
+		}
 	}
 	else if (0 == copystatus) { /* non-blocking mode only */
 	}

--- a/t/40replication.t
+++ b/t/40replication.t
@@ -1,0 +1,137 @@
+#!perl
+
+## Test the COPY functionality
+
+use 5.006;
+use strict;
+use warnings;
+use Data::Dumper;
+use Data::HexDump;
+use DBD::Pg ':async';
+use Test::More;
+use lib 't','.';
+require 'dbdpg_test_setup.pl';
+select(($|=1,select(STDERR),$|=1)[1]);
+
+use constant {
+    DUP_OBJ => '42710',
+    USECS   => 1_000_000,
+    PG_TO_UNIX_EPOCH_DELTA => 946_684_800,
+};
+
+my $slot = 'dbd_pg_test';
+my $plugin = 'test_decoding';
+
+my $dbh = connect_database();
+
+my $repl_dbh;
+if ($dbh) {
+    if ($dbh->{pg_server_version} >= 9.4) {
+        $repl_dbh = DBI->connect("$ENV{DBI_DSN};replication=database", $ENV{DBI_USER}, '',
+                                 {RaiseError => 1, PrintError => 0, AutoCommit => 1});
+        $repl_dbh->{pg_enable_utf8} = 0;
+    } else {
+        plan skip_all => 'Cannot test logical replication on Postgres < 9.4';
+    }
+}
+else {
+	plan skip_all => 'Connection to database failed, cannot continue testing';
+}
+
+ok defined $repl_dbh, 'Connect to database for logical replication testing';
+
+my ($systemid, $timeline, $xlogpos, $dbname) = $repl_dbh->selectrow_array('IDENTIFY_SYSTEM');
+
+ok $dbname, "connected to specific dbname=$dbname";
+
+my $rv;
+
+eval {
+    $rv = $repl_dbh->do(sprintf 'CREATE_REPLICATION_SLOT %s LOGICAL %s',
+                        $repl_dbh->quote_identifier($slot), $repl_dbh->quote_identifier($plugin));
+};
+if ($@) {
+    unless ($repl_dbh->state eq DUP_OBJ) {
+        die sprintf 'err: %s; errstr: %s; state: %s', $repl_dbh->err, $repl_dbh->errstr, $repl_dbh->state;
+    } else {
+        $rv = 1;
+    }
+}
+ok $rv, 'replication slot created';
+
+$rv = $repl_dbh->do(sprintf 'START_REPLICATION SLOT %s LOGICAL 0/0', $repl_dbh->quote_identifier($slot));
+ok $rv, 'replication started';
+
+my $lastlsn = 0;
+my $tx_watch;
+while (1) {
+    my @status = ('r', $lastlsn, $lastlsn, 0, ((time - PG_TO_UNIX_EPOCH_DELTA) * USECS), 0);
+    my $status = pack 'Aq>4b', @status;
+    $repl_dbh->pg_putcopydata($status)
+        or die sprintf 'err: %s; errstr: %s; state: %s', $repl_dbh->err, $repl_dbh->errstr, $repl_dbh->state;
+
+    unless ($tx_watch) {
+        $dbh->do('set client_min_messages to ERROR');
+        $dbh->do('drop table if exists dbd_pg_repltest');
+        $dbh->do('create table dbd_pg_repltest (id int)');
+        $dbh->do('insert into dbd_pg_repltest (id) values (1)');
+        $tx_watch = $dbh->selectrow_array('select txid_current()');
+        $dbh->commit;
+    }
+
+    my $n = $repl_dbh->pg_getcopydata_async(my $msg);
+
+    if ($n == 0) {
+        # nothing ready
+        sleep 1;
+        next;
+    }
+
+    if ($n == -1) {
+        # COPY closed
+        last;
+    }
+
+    if ($n == -2) {
+        die 'could not read COPY data: ' . $repl_dbh->errstr;
+    }
+
+    if ('k' eq substr $msg, 0, 1) {
+        my ($type, $lsnpos, $ts, $reply) = unpack 'Aq>2b', $msg;
+
+        $ts = ($ts / USECS) + PG_TO_UNIX_EPOCH_DELTA;
+
+        next;
+    }
+
+    if ('w' ne substr $msg, 0, 1) {
+        die sprintf 'unrecognized streaming header: "%s"', substr($msg, 0, 1);
+    }
+
+    my ($type, $startpos, $lsnpos, $ts, $record) = unpack 'Aq>3a*', $msg;
+
+    $ts = ($ts / USECS) + PG_TO_UNIX_EPOCH_DELTA;
+
+    if ($record eq 'table dbd_pg_testschema.dbd_pg_repltest: INSERT: id[integer]:1') {
+        pass 'saw insert event';
+        last;
+    } elsif ($tx_watch and my ($tx) = $record =~ /^COMMIT (\d+)$/) {
+        if ($tx > $tx_watch) {
+            fail 'saw insert event';
+            last;
+        }
+    }
+
+    $lastlsn = $lsnpos;
+}
+
+$repl_dbh->disconnect;
+
+# cleanup the replication slot and test table
+$dbh->do('select pg_drop_replication_slot(?)', undef, $slot);
+$dbh->do('drop table if exists dbd_pg_repltest');
+$dbh->commit;
+
+$dbh->disconnect;
+
+done_testing;

--- a/t/dbdpg_test_setup.pl
+++ b/t/dbdpg_test_setup.pl
@@ -518,6 +518,21 @@ version: $version
 			print $cfh "log_filename = 'postgres%Y-%m-%d.log'\n";
 			print $cfh "log_rotation_size = 0\n";
 
+			if ($version >= 9.4) {
+				print $cfh "wal_level = logical\n";
+				print $cfh "max_replication_slots = 1\n";
+				print $cfh "max_wal_senders = 1\n";
+
+				open my $hba, '>>', "$testdir/data/pg_hba.conf"
+					or die qq{Could not open "$testdir/data/pg_hba.conf": $!\n};
+
+				print $hba "local\treplication\tall\ttrust\n";
+				print $hba "host\treplication\tall\t127.0.0.1/32\ttrust\n";
+				print $hba "host\treplication\tall\t::1/128\ttrust\n";
+
+				close $hba or die qq{Could not close "$testdir/data/pg_hba.conf": $!\n};
+			}
+
 			print $cfh "listen_addresses='127.0.0.1'\n" if $^O =~ /Win32/;
 			print $cfh "\n";
 			close $cfh or die qq{Could not close "$conf": $!\n};


### PR DESCRIPTION
Postgres 9.4 introduced logical replication decoding, whose protocol is done via bidirectional COPY commands. This enhances the handling of COPY_BOTH such that one can use DBD::Pg as a logical replication client. The hard work would still be on the consumer application to handle the protocol. A crude test `40replication.t` show it working.