### PR TITLE
Add support for foreign tables in ->table_info

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,4 +1,7 @@
 
+  - Add support for foreign tables in table_info() and column_info()
+    [Dagfinn Ilmari Mannsåker]
+
 Version 3.7.4. Released February 12, 2018 (git tag 3.7.4)
 
   - Fix typo in META.yml


### PR DESCRIPTION
Not sure if "SYSTEM FOREIGN TABLE" is a thing, but I added that for consistency with "SYSTEM MATERIALIZED VIEW", which I'm similarly doubtful about.