### PR TITLE
Drop support for PostgreSQL before 8.0

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,9 @@
 
 Version 3.8.0
 
+  - Increase minimum supported PostgreSQL version to 8.0
+    [Dagfinn Ilmari Mannsåker]
+
   - Add support for foreign tables in table_info() and column_info()
     [Dagfinn Ilmari Mannsåker]
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -161,9 +161,9 @@ if ($os =~ /Win32/) {
 }
 
 ## Warn about older versions
-if ($serverversion < 70400) {
+if ($serverversion < 80000) {
     print "\n****************\n";
-    print "WARNING! DBD::Pg no longer supports versions less than 7.4.\n";
+    print "WARNING! DBD::Pg no longer supports versions less than 8.0.\n";
     print "You must upgrade PostgreSQL to a newer version.\n";
     print "****************\n\n";
     exit 1;

--- a/Pg.xs
+++ b/Pg.xs
@@ -789,8 +789,6 @@ _pg_type_info (type_sv=Nullsv)
 		ST(0) = sv_2mortal( newSViv( type_num ) );
 	}
 
-#if PGLIBVERSION >= 80000
-
 void
 pg_result(dbh)
 	SV * dbh
@@ -818,8 +816,6 @@ pg_cancel(dbh)
 	CODE:
 	D_imp_dbh(dbh);
 	ST(0) = pg_db_cancel(dbh, imp_dbh) ? &PL_sv_yes : &PL_sv_no;
-
-#endif
 
 
 # -- end of DBD::Pg::db
@@ -861,8 +857,6 @@ cancel(sth)
 	D_imp_sth(sth);
 	ST(0) = dbd_st_cancel(sth, imp_sth) ? &PL_sv_yes : &PL_sv_no;
 
-#if PGLIBVERSION >= 80000
-
 void
 pg_result(sth)
 	SV * sth
@@ -877,8 +871,6 @@ pg_result(sth)
 			XST_mUNDEF(0);
 		else
 			XST_mIV(0, ret);
-
-#endif
 
 SV*
 pg_canonical_ids(sth)

--- a/README.dev
+++ b/README.dev
@@ -175,7 +175,7 @@ t/09arrays.t - Tests array manipulation.
 
 t/12placeholders.t - Tests placeholders.
 
-t/20savepoints.t - Test savepoints. Requires a server version 8.0 or up.
+t/20savepoints.t - Test savepoints.
 
 t/30unicode.t - Test Unicode. Or at least UTF8.
 

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -23,7 +23,7 @@ struct imp_dbh_st {
 	int     copystate;         /* 0=none PGRES_COPY_IN PGRES_COPY_OUT */
 	bool    copybinary;        /* whether the copy is in binary format */
 	int     pg_errorlevel;     /* PQsetErrorVerbosity. Set by user, defaults to 1 */
-	int     server_prepare;    /* do we want to use PQexecPrepared? 0=no 1=yes 2=smart. Can be changed by user */
+	bool    server_prepare;    /* do we want to use PQexecPrepared? Can be changed by user */
 	int     switch_prepared;   /* how many executes until we switch to PQexecPrepared */
 	int     async_status;      /* 0=no async 1=async started -1=async has been cancelled */
 
@@ -88,7 +88,7 @@ typedef enum
 struct imp_sth_st {
 	dbih_stc_t com;          /* MUST be first element in structure */
 
-	int    server_prepare;    /* inherited from dbh. 3 states: 0=no 1=yes 2=smart */
+	bool   server_prepare;    /* inherited from dbh */
 	int    switch_prepared;   /* inherited from dbh */
     int    number_iterations; /* how many times has the statement been executed? Used by switch_prepared */
 	PGPlaceholderType placeholder_type;  /* which style is being used 1=? 2=$1 3=:foo */

--- a/t/03dbmethod.t
+++ b/t/03dbmethod.t
@@ -768,11 +768,6 @@ is_deeply (\@result, $expected, $t);
 # Test of the "statistics_info" database handle method
 #
 
-SKIP: {
-
-$dbh->{private_dbdpg}{version} >= 80000
-	or skip ('Server must be version 8.0 or higher to test database handle method "statistics_info"', 10);
-
 $t='DB handle method "statistics_info" returns undef: no table';
 $sth = $dbh->statistics_info(undef,undef,undef,undef,undef);
 is ($sth, undef, $t);
@@ -903,7 +898,7 @@ $dbh->do("DROP TABLE $table3");
 $dbh->do("DROP TABLE $table2");
 $dbh->do("DROP TABLE $table1");
 
-} ## end of statistics_info tests
+## end of statistics_info tests
 
 #
 # Test of the "foreign_key_info" database handle method

--- a/t/03smethod.t
+++ b/t/03smethod.t
@@ -25,8 +25,6 @@ plan tests => 126;
 
 isnt ($dbh, undef, 'Connect to database for statement handle method testing');
 
-my $pglibversion = $dbh->{pg_lib_version};
-
 my ($SQL, $sth, $sth2, $result, @result, $expected, $rows, $t);
 
 #
@@ -96,19 +94,11 @@ for (1..4) {
 	ok ($sth->execute, $it);
 }
 
-## 7.4 does not have a full SSP implementation, so we simply skip these tests.
-if ($pglibversion < 80000) {
- SKIP: {
-		skip ('Not testing pg_server_prepare on 7.4-compiled servers', 2);
-	}
-}
-else {
-	$t='Prepare/execute with pg_server_prepare on at database handle works';
-	$dbh->{pg_server_prepare} = 1;
-	$sth = $dbh->prepare($SQL);
-	$sth->execute(1);
-	ok ($sth->execute, $t);
-}
+$t='Prepare/execute with pg_server_prepare on at database handle works';
+$dbh->{pg_server_prepare} = 1;
+$sth = $dbh->prepare($SQL);
+$sth->execute(1);
+ok ($sth->execute, $t);
 
 ## We must send a hashref as the final arg
 $t='Prepare failes when sent a non-hashref';
@@ -128,12 +118,10 @@ $sth = $dbh->prepare($SQL, {pg_server_prepare => 0});
 $sth->execute(1);
 ok ($sth->execute, $t);
 
-if ($pglibversion >= 80000) {
-	$t='Prepare/execute with pg_server_prepare on at statement handle works';
-	$sth = $dbh->prepare($SQL, {pg_server_prepare => 1});
-	$sth->execute(1);
-	ok ($sth->execute, $t);
-}
+$t='Prepare/execute with pg_server_prepare on at statement handle works';
+$sth = $dbh->prepare($SQL, {pg_server_prepare => 1});
+$sth->execute(1);
+ok ($sth->execute, $t);
 
 $t='Prepare/execute with pg_prepare_now on at database handle works';
 $dbh->{pg_prepare_now} = 1;
@@ -701,11 +689,6 @@ is ($sth->{pg_current_row}, 0, $t);
 #
 
 SKIP: {
-	## 7.4 does not have cancel
-	if ($pglibversion < 80000) {
-		skip ('Not testing cancel 7.4-compiled servers', 1);
-	}
-
 	if ($^O =~ /Win/) {
 		skip ('Cannot test POSIX signalling on Windows', 1);
 	}

--- a/t/08async.t
+++ b/t/08async.t
@@ -18,14 +18,6 @@ if (! $dbh) {
 	plan skip_all => 'Connection to database failed, cannot continue testing';
 }
 
-my $pglibversion = $dbh->{pg_lib_version};
-
-if ($pglibversion < 80000) {
-	cleanup_database($dbh,'test');
-	$dbh->disconnect;
-	plan skip_all => 'Cannot run asynchronous queries with pre-8.0 libraries.';
-}
-
 plan tests => 67;
 
 isnt ($dbh, undef, 'Connect to database for async testing');

--- a/t/12placeholders.t
+++ b/t/12placeholders.t
@@ -22,7 +22,7 @@ plan tests => 259;
 my $t='Connect to database for placeholder testing';
 isnt ($dbh, undef, $t);
 
-my ($pglibversion,$pgversion) = ($dbh->{pg_lib_version},$dbh->{pg_server_version});
+my $pgversion = $dbh->{pg_server_version};
 if ($pgversion >= 80100) {
   $dbh->do('SET escape_string_warning = false');
 }
@@ -479,17 +479,12 @@ eval {
 };
 is ($@, q{}, $t);
 
-SKIP: {
-	if ($pglibversion < 80000) {
-		skip ('Skipping specific placeholder test on 7.4-compiled servers', 1);
-	}
-	$t='Calling do() with invalid crowded placeholders fails cleanly';
-	$dbh->commit();
-	eval {
-		$dbh->do(q{SELECT ??}, undef, 'public', 'error');
-	};
-	is ($dbh->state, '42601', $t);
-}
+$t='Calling do() with invalid crowded placeholders fails cleanly';
+$dbh->commit();
+eval {
+    $dbh->do(q{SELECT ??}, undef, 'public', 'error');
+};
+is ($dbh->state, '42601', $t);
 
 $t='Prepare/execute with non-DML placeholder works';
 $dbh->commit();
@@ -625,9 +620,6 @@ eval {
 };
 is ($@, q{}, $t);
 
-SKIP: {
-	skip 'Cannot run some quote tests on very old versions of Postgres', 14 if $pgversion < 80000;
-
 $t='Prepare works with placeholders after double slashes';
 eval {
 	$dbh->do(q{CREATE OPERATOR // ( PROCEDURE=bit, LEFTARG=int, RIGHTARG=int )});
@@ -683,8 +675,6 @@ SKIP: {
 		};
 		is ($@, q{}, $t);
 	}
-}
-
 }
 
 SKIP: {

--- a/t/20savepoints.t
+++ b/t/20savepoints.t
@@ -20,48 +20,42 @@ plan tests => 3;
 
 isnt ($dbh, undef, 'Connect to database for savepoint testing');
 
-my $pgversion = $dbh->{pg_server_version};
-
 my $t;
 
-SKIP: {
-	skip ('Cannot test savepoints on pre-8.0 servers', 2) if $pgversion < 80000;
+my $str = 'Savepoint Test';
+my $sth = $dbh->prepare('INSERT INTO dbd_pg_test (id,pname) VALUES (?,?)');
 
-	my $str = 'Savepoint Test';
-	my $sth = $dbh->prepare('INSERT INTO dbd_pg_test (id,pname) VALUES (?,?)');
+## Create 500 without a savepoint
+$sth->execute(500,$str);
 
-	## Create 500 without a savepoint
-	$sth->execute(500,$str);
+## Create 501 inside a savepoint and roll it back
+$dbh->pg_savepoint('dbd_pg_test_savepoint');
+$sth->execute(501,$str);
 
-	## Create 501 inside a savepoint and roll it back
-	$dbh->pg_savepoint('dbd_pg_test_savepoint');
-	$sth->execute(501,$str);
+$dbh->pg_rollback_to('dbd_pg_test_savepoint');
+$dbh->pg_rollback_to('dbd_pg_test_savepoint'); ## Yes, we call it twice
 
-	$dbh->pg_rollback_to('dbd_pg_test_savepoint');
-	$dbh->pg_rollback_to('dbd_pg_test_savepoint'); ## Yes, we call it twice
+## Create 502 after the rollback:
+$sth->execute(502,$str);
 
-	## Create 502 after the rollback:
-	$sth->execute(502,$str);
+$dbh->commit;
 
-	$dbh->commit;
+$t='Only row 500 and 502 should be committed';
+my $ids = $dbh->selectcol_arrayref('SELECT id FROM dbd_pg_test WHERE pname = ?',undef,$str);
+ok (eq_set($ids, [500, 502]), $t);
 
-	$t='Only row 500 and 502 should be committed';
-	my $ids = $dbh->selectcol_arrayref('SELECT id FROM dbd_pg_test WHERE pname = ?',undef,$str);
-	ok (eq_set($ids, [500, 502]), $t);
+## Create 503, then release the savepoint
+$dbh->pg_savepoint('dbd_pg_test_savepoint');
+$sth->execute(503,$str);
+$dbh->pg_release('dbd_pg_test_savepoint');
 
-	## Create 503, then release the savepoint
-	$dbh->pg_savepoint('dbd_pg_test_savepoint');
-	$sth->execute(503,$str);
-	$dbh->pg_release('dbd_pg_test_savepoint');
+## Create 504 outside of any savepoint
+$sth->execute(504,$str);
+$dbh->commit;
 
-	## Create 504 outside of any savepoint
-	$sth->execute(504,$str);
-	$dbh->commit;
-
-	$t='Implicit rollback on deallocate should rollback to last savepoint';
-	$ids = $dbh->selectcol_arrayref('SELECT id FROM dbd_pg_test WHERE pname = ?',undef,$str);
-	ok (eq_set($ids, [500, 502, 503, 504]), $t);
-}
+$t='Implicit rollback on deallocate should rollback to last savepoint';
+$ids = $dbh->selectcol_arrayref('SELECT id FROM dbd_pg_test WHERE pname = ?',undef,$str);
+ok (eq_set($ids, [500, 502, 503, 504]), $t);
 
 $dbh->do('DELETE FROM dbd_pg_test');
 $dbh->commit();

--- a/t/dbdpg_test_setup.pl
+++ b/t/dbdpg_test_setup.pl
@@ -499,15 +499,10 @@ version: $version
 			print $cfh "\n\n## DBD::Pg testing parameters\n";
 			print $cfh "port=$testport\n";
 			print $cfh "max_connections=11\n";
-			if ($version >= 8.0) {
-				print $cfh "log_statement = 'all'\n";
-				print $cfh "log_line_prefix = '%m [%p] '\n";
-				print $cfh "log_filename = 'postgres%Y-%m-%d.log'\n";
-				print $cfh "log_rotation_size = 0\n";
-			}
-			else {
-				print $cfh "silent_mode = true\n";
-			}
+			print $cfh "log_statement = 'all'\n";
+			print $cfh "log_line_prefix = '%m [%p] '\n";
+			print $cfh "log_filename = 'postgres%Y-%m-%d.log'\n";
+			print $cfh "log_rotation_size = 0\n";
 			if ($version == 8.1) {
 				print {$cfh} "redirect_stderr = on\n";
 			}


### PR DESCRIPTION
We currently (since 2007) support PostgreSQL back to version 7.4, which has been out of
support upstream since 2010.  By dropping support for versions before 8.0 we can get rid
of several bits of cruft:

- PQprepare() emulation
- PQserverVersion() emulation
- "smart" pg_server_prepare mode
- conditional catalog SQL query fragments