### PR TITLE
Fix encoding in $dbh->do() function

### DIFF
--- a/Pg.xs
+++ b/Pg.xs
@@ -317,15 +317,20 @@ void state(dbh)
           : sv_2mortal(newSVpv(imp_dbh->sqlstate, 5));
 
 
-void do(dbh, statement, attr=Nullsv, ...)
+void do(dbh, statement_sv, attr=Nullsv, ...)
 	SV * dbh
-	char * statement
+	SV * statement_sv
 	SV * attr
 	PROTOTYPE: $$;$@
 	CODE:
 	{
 		long retval;
 		int asyncflag = 0;
+		char *statement;
+		D_imp_dbh(dbh);
+
+		statement_sv = pg_rightgraded_sv(aTHX_ statement_sv, imp_dbh->pg_utf8_flag);
+		statement = SvPV_nolen(statement_sv);
 
 		if (statement[0] == '\0') { /* Corner case */
 			XST_mUNDEF(0);


### PR DESCRIPTION
Use same logic with pg_rightgraded_sv() as in dbd_st_prepare_sv() function
for statement_sv variable.

Prior this patch calling following code

    $dbh->do("CREATE TEMPORARY TABLE t(s VARCHAR(10))");
    $dbh->do("INSERT INTO t(s) VALUES('\xC3\xA1')");
    my $ret = $dbh->selectrow_array("SELECT s FROM t");

returned "\xE1" and not "\xC3\xA1" as expected.

On the other hand calling following code

    $dbh->do("CREATE TEMPORARY TABLE t(s VARCHAR(10))");
    my $sth = $dbh->prepare("INSERT INTO t(s) VALUES('\xC3\xA1')");
    $sth->execute();
    my $ret = $dbh->selectrow_array("SELECT s FROM t");

which is semantically same returned correct value "\xC3\xA1".

Fixes: https://rt.cpan.org/Public/Bug/Display.html?id=122991