### PR TITLE
Fix encoding of SQL_VARBINARY type in $dbh->quote() function

### DIFF
--- a/Pg.xs
+++ b/Pg.xs
@@ -283,7 +283,7 @@ quote(dbh, to_quote_sv, type_sv=Nullsv)
 			}
 
 			/* At this point, type_info points to a valid struct, one way or another */
-			utf8 = imp_dbh->client_encoding_utf8 && PG_BYTEA != type_info->type_id;
+			utf8 = imp_dbh->client_encoding_utf8 && PG_BYTEA != type_info->type_id && SQL_VARBINARY != type_info->type_id;
 
 			if (SvMAGICAL(to_quote_sv))
 				(void)mg_get(to_quote_sv);

--- a/t/06bytea.t
+++ b/t/06bytea.t
@@ -17,7 +17,7 @@ my $dbh = connect_database();
 if (! $dbh) {
 	plan skip_all => 'Connection to database failed, cannot continue testing';
 }
-plan tests => 16;
+plan tests => 18;
 
 isnt ($dbh, undef, 'Connect to database for bytea testing');
 
@@ -95,5 +95,6 @@ sub test_outputs {
     my $E = $pgversion >= 80100 ? q{E} : q{};
     my $expected = qq{${E}'abc\123\\\\\\\\def\\\\000ghi'};
     is ($result, $expected, $t);
+    is ($dbh->quote($string, SQL_VARBINARY), $expected);
 	return;
 }


### PR DESCRIPTION
For SQL_VARBINARY DBI type use same logic as for PG_BYTEA type.
SQL_VARBINARY DBI type is just alias for PG_BYTEA type, so result of
quoting operation should be same.

Prior this patch following code

    $dbh->quote("\xC3\xA1", SQL_VARBINARY)

returned

    E'\\303\\203\\302\\241'

And

    $dbh->quote("\xC3\xA1", { pg_type => PG_BYTEA })

returned

    E'\\303\\241'

Now with this patch both PG_BYTEA and SQL_VARBINARY return same value

    E'\\303\\241'

which is correct.