### PR TITLE
Support partitioned tables with pg_class.relkind = 'p'

### DIFF
--- a/Pg.pm
+++ b/Pg.pm
@@ -508,7 +508,7 @@ use 5.008001;
                 JOIN pg_catalog.pg_namespace n ON (n.oid = c.relnamespace)
             WHERE
                 a.attnum >= 0
-                AND c.relkind IN ('r','v','m','f')
+                AND c.relkind IN ('r','p','v','m','f')
                 $whereclause
             ORDER BY "TABLE_SCHEM", "TABLE_NAME", "ORDINAL_POSITION"
             !;
@@ -1005,8 +1005,8 @@ use 5.008001;
                     uk_constr.oid = dep2.refobjid AND uk_constr.contype IN ('p','u')
                 )
             WHERE $WHERE
-                AND uk_class.relkind = 'r'
-                AND fk_class.relkind = 'r'
+                AND uk_class.relkind ~ 'r|p'
+                AND fk_class.relkind ~ 'r|p'
                 AND constr.contype = 'f'
             ORDER BY constr.conname, colnum.i
         };
@@ -1088,10 +1088,10 @@ use 5.008001;
                             , NULL::text AS "TABLE_NAME") dummy_cols
                     CROSS JOIN
                       (SELECT 'TABLE'        AS "TABLE_TYPE"
-                            , 'relkind: r'   AS "REMARKS"
+                            , 'relkind ~ r|p'   AS "REMARKS"
                        UNION
                        SELECT 'SYSTEM TABLE'
-                            , 'relkind: r; nspname ~ ^pg_(catalog|toast)$'
+                            , 'relkind ~ r|p; nspname ~ ^pg_(catalog|toast)$'
                        UNION
                        SELECT 'VIEW'
                             , 'relkind: v'
@@ -1112,14 +1112,14 @@ use 5.008001;
                             , 'relkind: f; nspname ~ ^pg_(catalog|toast)$'
                        UNION
                        SELECT 'LOCAL TEMPORARY'
-                            , 'relkind: r; nspname ~ ^pg_(toast_)?temp') type_info
+                            , 'relkind ~ r|p; nspname ~ ^pg_(toast_)?temp') type_info
                      ORDER BY "TABLE_TYPE" ASC
                 };
         }
         else {
             # Default SQL
             $extracols = q{,n.nspname AS pg_schema, c.relname AS pg_table};
-            my @search = (q|c.relkind IN ('r', 'v', 'm', 'f')|, # No sequences, etc. for now
+            my @search = (q|c.relkind IN ('r', 'p', 'v', 'm', 'f')|, # No sequences, etc. for now
                           q|NOT (pg_catalog.quote_ident(n.nspname) ~ '^pg_(toast_)?temp_' AND NOT pg_catalog.has_schema_privilege(n.nspname, 'USAGE'))|);   # No others' temp objects
             my $showtablespace = ', pg_catalog.quote_ident(t.spcname) AS "pg_tablespace_name", pg_catalog.quote_ident(t.spclocation) AS "pg_tablespace_location"';
             if ($dbh->{private_dbdpg}{version} >= 90200) {
@@ -1142,7 +1142,7 @@ use 5.008001;
                        -- any temp table or temp view is LOCAL TEMPORARY for us
                      , CASE WHEN pg_catalog.quote_ident(n.nspname) ~ '^pg_(toast_)?temp_' THEN
                                  'LOCAL TEMPORARY'
-                            WHEN c.relkind = 'r' THEN
+                            WHEN c.relkind ~ 'r|p' THEN
                                  CASE WHEN pg_catalog.quote_ident(n.nspname) ~ '^pg_' THEN
                                            'SYSTEM TABLE'
                                       ELSE 'TABLE'


### PR DESCRIPTION
When partitioned tables exist `$dbh->table_info()` is currently listing all the partitions (which are stored as tables, so it makes sense) but it does not include the parent partitioned tables, introduced in Postgres 10 with `relkind = 'p'`.

An alternative approach could be to create a new `TABLE_TYPE` value for partitioned tables.