### PR TITLE
Add DBI SQL_BLOB, SQL_BINARY and SQL_LONGVARBINARY types as alias for PG_BYTEA

### DIFF
--- a/Pg.xs
+++ b/Pg.xs
@@ -283,7 +283,12 @@ quote(dbh, to_quote_sv, type_sv=Nullsv)
 			}
 
 			/* At this point, type_info points to a valid struct, one way or another */
-			utf8 = imp_dbh->client_encoding_utf8 && PG_BYTEA != type_info->type_id && SQL_VARBINARY != type_info->type_id;
+			utf8 = imp_dbh->client_encoding_utf8
+				&& PG_BYTEA != type_info->type_id
+				&& SQL_BLOB != type_info->type_id
+				&& SQL_BINARY != type_info->type_id
+				&& SQL_VARBINARY != type_info->type_id
+				&& SQL_LONGVARBINARY != type_info->type_id;
 
 			if (SvMAGICAL(to_quote_sv))
 				(void)mg_get(to_quote_sv);

--- a/types.c
+++ b/types.c
@@ -376,6 +376,9 @@ static sql_type_info_t sql_types[] = {
  {SQL_TYPE_TIMESTAMP_WITH_TIMEZONE,"SQL_TYPE_TIMESTAMP_WITH_TIMEZONE",1,',', "none", quote_string, dequote_string, {PG_TIMESTAMPTZ}, 0},
  {SQL_TYPE_TIME_WITH_TIMEZONE,"SQL_TYPE_TIME_WITH_TIMEZONE",1,',', "none", quote_string, dequote_string, {PG_TIMESTAMPTZ}, 0},
  {SQL_VARCHAR,"SQL_VARCHAR",1,',', "none", quote_string, dequote_string, {PG_VARCHAR}, 0},
+ {SQL_BLOB,"SQL_BLOB",1,',', "none", quote_bytea, dequote_bytea, {PG_BYTEA}, 0},
+ {SQL_BINARY,"SQL_BINARY",1,',', "none", quote_bytea, dequote_bytea, {PG_BYTEA}, 0},
+ {SQL_LONGVARBINARY,"SQL_LONGVARBINARY",1,',', "none", quote_bytea, dequote_bytea, {PG_BYTEA}, 0},
 };
 
 sql_type_info_t* sql_type_data(int sql_type)
@@ -401,6 +404,9 @@ sql_type_info_t* sql_type_data(int sql_type)
 		case SQL_TYPE_TIMESTAMP_WITH_TIMEZONE: return &sql_types[19];
 		case SQL_TYPE_TIME_WITH_TIMEZONE:      return &sql_types[20];
 		case SQL_VARCHAR:                      return &sql_types[21];
+		case SQL_BLOB:                         return &sql_types[22];
+		case SQL_BINARY:                       return &sql_types[23];
+		case SQL_LONGVARBINARY:                return &sql_types[24];
 		default: return NULL;
 	}
 }


### PR DESCRIPTION
DBI type SQL_VARBINARY is already aliased to PG_BYTEA. Other DBI drivers
use these DBI types for binding binary data so also add them to DBD::Pg.