### PR TITLE
Fix a segfault related to async statements

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -684,6 +684,8 @@ void dbd_db_destroy (SV * dbh, imp_dbh_t * imp_dbh)
 		if (imp_dbh->async_sth->result) {
 			TRACE_PQCLEAR;
 			PQclear(imp_dbh->async_sth->result);
+			if (imp_dbh->last_result == imp_dbh->async_sth->result)
+				imp_dbh->last_result = NULL;
 		}
 		imp_dbh->async_sth = NULL;
 	}
@@ -5169,8 +5171,13 @@ long pg_db_result (SV *h, imp_dbh_t *imp_dbh)
 
 		if (imp_dbh->async_sth) {
 			if (imp_dbh->async_sth->result) { /* For potential multi-result sets */
-				TRACE_PQCLEAR;
-				PQclear(imp_dbh->async_sth->result);
+				if (imp_dbh->sth_result_owner == (long int)imp_dbh->async_sth) {
+					imp_dbh->sth_result_owner = 0;
+				}
+				else {
+					TRACE_PQCLEAR;
+					PQclear(imp_dbh->async_sth->result);
+				}
 			}
 			imp_dbh->async_sth->result = result;
 		}


### PR DESCRIPTION
Hi friends,

After upgrading to DBD::Pg 3.10.0, my async app now dies on "Segmentation fault" or "double free or corruption". The exact place it dies is inconsistent, but capturing various backtraces reveals it's always in `PQclear`. So it seems clear we're attempting to free a result more than once. Here's a sample backtrace:

    #0  0x00007fe110a45a90 in free () from /lib64/libc.so.6                                                               
    #1  0x00007fe10d30f9fe in PQclear () from /usr/lib64/postgresql-11/lib64/libpq.so.5                                   
    #2  0x00007fe10d358089 in _result () from .../lib/perl5/x86_64-linux/auto/DBD/Pg/Pg.so
    #3  0x00007fe10d35994c in pg_st_deallocate_statement.isra () from .../lib/perl5/x86_64-linux/auto/DBD/Pg/Pg.so
    #4  0x00007fe10d365023 in pg_st_destroy () from .../lib/perl5/x86_64-linux/auto/DBD/Pg/Pg.so
    #5  0x00007fe10d352ea6 in XS_DBD__Pg__st_DESTROY () from .../lib/perl5/x86_64-linux/auto/DBD/Pg/Pg.so
    #6  0x00007fe10d3939b8 in XS_DBI_dispatch () from .../lib/perl5/x86_64-linux/auto/DBI/DBI.so
    #7  0x000055c2a3321179 in Perl_pp_entersub ()
    ...

I bisected to b312efbfd7e605286f00ad373d42c9b2e6b0c13d (made prior to 3.9.0).

I took a stab at fixing the problem and came to this solution. This *does* alleviate the segfaults for me, though I'd need someone more familiar with this code to verify it's the right solution.

Although it crashes consistently in my complex app, I haven't yet succeeded in even reproducing the crash in a test file. :-(

