### PR TITLE
fix test on 32-bit systems and problem with blessed placeholder values

### DIFF
--- a/t/04misc.t
+++ b/t/04misc.t
@@ -5,6 +5,7 @@
 use 5.006;
 use strict;
 use warnings;
+use bignum;
 use Test::More;
 use Data::Dumper;
 use DBI;


### PR DESCRIPTION
A test was failing on 32-bit systems related to PG_MIN_BIGINT:

>t/04misc.t .. 1/101 DBD::Pg::st execute failed: ERROR:  invalid input syntax for integer: "-9.22337203685478e+18" at t/04misc.t line 87.

I'm not sure what the best solution is. I just added a "use bignum" to that test file. Looks like bignum was added to core in 5.8. I don't know if that's acceptable or not.

Also, there was a problem with handling blessed objects (see my example on issue #63).
It appeared to be due to the ordering of tests, where a Time::Piece instance was being treated as an array ref. I reordered that section a bit.
