### PR TITLE
Fix segfault during st destroy

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -4017,6 +4017,8 @@ void dbd_st_destroy (SV * sth, imp_sth_t * imp_sth)
     ph_t *  currph;
     ph_t *  nextph;
 
+    imp_dbh->do_tmp_sth = NULL;
+
     if (TSTART_slow) TRC(DBILOGFP, "%sBegin dbd_st_destroy\n", THEADER_slow);
 
     if (NULL == imp_sth->seg) /* Already been destroyed! */


### PR DESCRIPTION
This fixes #57 

As mentioned in that issue, the underlying cause is #52. I am not sure that this is the right fix, but the issue seems to be the fact that the `imp_dbh` is left with an invalid `do_tmp_sth` after an earlier `do` call, which `pg_st_FETCH_attrib` tries to use. The design of `do_tmp_sth` seems prone to this sort of issue.