### PR TITLE
Add `pg_is_key_column` field to `statistics_info`

### DIFF
--- a/Changes
+++ b/Changes
@@ -3,6 +3,10 @@ Changes for the DBD::Pg module
 RT refers to rt.cpan.org
 
 
+ - Return an empty result set instead of undef from statistics_info
+   when the requested table doesn't exist and $unique_only is false.
+   [Dagfinn Ilmari Mannsåker]
+
 Version 3.10.5  (released March 23, 2020)
 
  - Minor adjustment for Windows build

--- a/Changes
+++ b/Changes
@@ -2,6 +2,8 @@ Changes for the DBD::Pg module
 
 RT refers to rt.cpan.org
 
+ - Indicate non-key index columns (INCLUDE) in statistics_info
+   [Dagfinn Ilmari Mannsåker]
 
  - Return an empty result set instead of undef from statistics_info
    when the requested table doesn't exist and $unique_only is false.

--- a/t/03dbmethod.t
+++ b/t/03dbmethod.t
@@ -25,7 +25,7 @@ my $dbh = connect_database();
 if (! $dbh) {
     plan skip_all => 'Connection to database failed, cannot continue testing';
 }
-plan tests => 586;
+plan tests => 589;
 
 isnt ($dbh, undef, 'Connect to database for database handle method testing');
 
@@ -903,6 +903,10 @@ $t='DB handle method "statistics_info" returns undef: no table';
 $sth = $dbh->statistics_info(undef,undef,undef,undef,undef);
 is ($sth, undef, $t);
 
+$t='DB handle method "statistics_info" returns undef: empty table';
+$sth = $dbh->statistics_info(undef,undef,'',undef,undef);
+is ($sth, undef, $t);
+
 ## Invalid table
 $t='DB handle method "statistics_info" returns undef: bad table';
 $sth = $dbh->statistics_info(undef,undef,'dbd_pg_test9',undef,undef);
@@ -972,6 +976,12 @@ one => [
     ],
 };
 
+my @stats_columns = qw(
+    TABLE_CAT TABLE_SCHEM TABLE_NAME NON_UNIQUE INDEX_QUALIFIER INDEX_NAME TYPE
+    ORDINAL_POSITION COLUMN_NAME ASC_OR_DESC CARDINALITY PAGES FILTER_CONDITION
+    pg_expression
+);
+
 ## Make some per-version tweaks
 
 ## 8.5 changed the way foreign key names are generated
@@ -998,10 +1008,16 @@ $stats = $sth->fetchall_arrayref;
 $correct_stats->{three}[$hash_index_idx][11] = $stats->[$hash_index_idx][11] = 0;
 is_deeply ($stats, $correct_stats->{three}, $t);
 
+$t = "Correct stats column names";
+is_deeply ($sth->{NAME}, \@stats_columns, $t);
+
 $t="Correct stats output for $table3 (unique only)";
 $sth = $dbh->statistics_info(undef,$schema,$table3,1,undef);
 $stats = $sth->fetchall_arrayref;
 is_deeply ($stats, $correct_stats->{three_uo}, $t);
+
+$t = "Correct stats column names (unique only)";
+is_deeply ($sth->{NAME}, \@stats_columns, $t);
 
 {
     $t="Correct stats output for $table1";

--- a/t/03dbmethod.t
+++ b/t/03dbmethod.t
@@ -908,9 +908,11 @@ $sth = $dbh->statistics_info(undef,undef,'',undef,undef);
 is ($sth, undef, $t);
 
 ## Invalid table
-$t='DB handle method "statistics_info" returns undef: bad table';
+$t='DB handle method "statistics_info" returns no rows: bad table';
 $sth = $dbh->statistics_info(undef,undef,'dbd_pg_test9',undef,undef);
-is ($sth, undef, $t);
+$result = $sth->fetchall_arrayref;
+$expected = [];
+is_deeply ($result, $expected, $t);
 
 
 my $with_oids = $pgversion < 120000 ? 'WITH OIDS' : '';


### PR DESCRIPTION
This field is true for normal columns, but false for non-key columns (specified using the `INCLUDE` clause in PostgreSQL 11+).

In passing, move the entire `statistics_info` response generation into SQL, avoiding repetitive and mistake-prone munging on the perl side, as well as buffering via `DBD::Sponge`.