### PR TITLE
More statistics_info fixups

### DIFF
--- a/Changes
+++ b/Changes
@@ -6,6 +6,10 @@ Version 3.11.2  (unrleased)
 
  - Add CONTRIBUTING.md file
 
+ - Return the table info row last in statistics_info.
+    This fixes statistics_info on pre-8.3 servers.
+   [Dagfinn Ilmari Mannsåker]
+
 
 Version 3.11.1  (released April 28, 2020)
 

--- a/Changes
+++ b/Changes
@@ -13,6 +13,9 @@ Version 3.11.2  (unrleased)
  - Fix ASC_OR_DESC field in statistics_info
    [Dagfinn Ilmari Mannsåker]
 
+ - Indicate NULL ordering in statitics_info
+   [Dagfinn Ilmari Mannsåker]
+
 
 Version 3.11.1  (released April 28, 2020)
 

--- a/Changes
+++ b/Changes
@@ -10,6 +10,9 @@ Version 3.11.2  (unrleased)
     This fixes statistics_info on pre-8.3 servers.
    [Dagfinn Ilmari Mannsåker]
 
+ - Fix ASC_OR_DESC field in statistics_info
+   [Dagfinn Ilmari Mannsåker]
+
 
 Version 3.11.1  (released April 28, 2020)
 

--- a/Pg.pm
+++ b/Pg.pm
@@ -640,9 +640,6 @@ use 5.008001;
             push(@exe_args, $schema);
         }
 
-        my $is_key_column = $dbh->{private_dbdpg}{version} >= 110000
-            ? 'col.i <= i.indnkeyatts' : 'true';
-
         my $stats_sql;
 
         # Table-level stats
@@ -671,6 +668,9 @@ use 5.008001;
             };
             push @exe_args, @exe_args;
         }
+
+        my $is_key_column = $dbh->{private_dbdpg}{version} >= 110000
+            ? 'col.i <= i.indnkeyatts' : 'true';
 
         # Fetch the index definitions
         $stats_sql .= qq{

--- a/Pg.pm
+++ b/Pg.pm
@@ -710,8 +710,7 @@ use 5.008001;
                 d.relname = ? $schema_where
                 AND (i.indisunique OR NOT(?)) -- unique_only
             ORDER BY
-                -- NULLS FIRST to get the table level stats first
-                "NON_UNIQUE" NULLS FIRST, "TYPE", "INDEX_QUALIFIER", "INDEX_NAME", "ORDINAL_POSITION"
+                "NON_UNIQUE", "TYPE", "INDEX_QUALIFIER", "INDEX_NAME", "ORDINAL_POSITION"
         };
 
         my $sth = $dbh->prepare($stats_sql);

--- a/t/03dbmethod.t
+++ b/t/03dbmethod.t
@@ -920,6 +920,8 @@ my $with_include = $pgversion >= 110000;
 my $hash_index_idx = 3;
 $hash_index_idx += 1 if $with_oids;
 $hash_index_idx += 2 if $with_include;
+my ($desc, $d) = $pgversion >= 80300 ? ('DESC', 'D') : ('', 'A');
+
 ## Create some tables with various indexes
 {
     local $SIG{__WARN__} = sub {};
@@ -940,7 +942,7 @@ $hash_index_idx += 2 if $with_include;
     $dbh->do("CREATE UNIQUE INDEX dbd_pg_test1_index_c ON $table1(c)");
 
     $dbh->do("CREATE TABLE $table2 (a INT, b INT, c INT, PRIMARY KEY(a,b), UNIQUE(b,c))");
-    $dbh->do("CREATE INDEX dbd_pg_test2_expr ON $table2((a+b),c)");
+    $dbh->do("CREATE INDEX dbd_pg_test2_expr ON $table2((a+b) $desc, c $desc)");
 
     $dbh->do("CREATE TABLE $table3 (a INT, b INT, c INT, PRIMARY KEY(a)) $with_oids");
     $dbh->do("CREATE UNIQUE INDEX dbd_pg_test3_index_b ON $table3(b)");
@@ -964,26 +966,26 @@ one => [
     [ $dbh->{pg_db}, $schema, $table2, '0', undef, 'dbd_pg_test2_b_key',   'btree',  2, 'c', 'A', '0', '1', undef, 'c', '1' ],
     [ $dbh->{pg_db}, $schema, $table2, '0', undef, 'dbd_pg_test2_pkey',    'btree',  1, 'a', 'A', '0', '1', undef, 'a', '1' ],
     [ $dbh->{pg_db}, $schema, $table2, '0', undef, 'dbd_pg_test2_pkey',    'btree',  2, 'b', 'A', '0', '1', undef, 'b', '1' ],
-    [ $dbh->{pg_db}, $schema, $table2, '1', undef, 'dbd_pg_test2_expr',    'btree',  1, undef, 'A', '0', '1', undef, '(a + b)', '1' ],
-    [ $dbh->{pg_db}, $schema, $table2, '1', undef, 'dbd_pg_test2_expr',    'btree',  2, 'c', 'A', '0', '1', undef, 'c', '1' ],
+    [ $dbh->{pg_db}, $schema, $table2, '1', undef, 'dbd_pg_test2_expr',    'btree',  1, undef, $d, '0', '1', undef, '(a + b)', '1' ],
+    [ $dbh->{pg_db}, $schema, $table2, '1', undef, 'dbd_pg_test2_expr',    'btree',  2, 'c', $d, '0', '1', undef, 'c', '1' ],
     [ $dbh->{pg_db}, $schema, $table2, undef, undef, undef, 'table', undef, undef, undef, '0', '0', undef, undef, undef ],
     ],
     three => [
     ($with_include ? (
         [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_incl',    'btree',  1, 'b', 'A', '0', '1', undef, 'b', '1' ],
-        [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_incl',    'btree',  2, 'c', 'A', '0', '1', undef, 'c', '0' ],
+        [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_incl',    'btree',  2, 'c', undef, '0', '1', undef, 'c', '0' ],
     ) :()),
     [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_index_b', 'btree',  1, 'b', 'A', '0', '1', undef, 'b', '1' ],
     [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_pkey',    'btree',  1, 'a', 'A', '0', '1', undef, 'a', '1' ],
     [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_pred',    'btree',  1, 'c', 'A', '0', '1', '((c > 0) AND (c < 45))', 'c', '1' ],
     ($with_oids ? [ $dbh->{pg_db}, $schema, $table3, '1', undef, 'dbd_pg_test3_oid',     'btree',  1, 'oid', 'A', '0', '1', undef, 'oid', '1' ] : ()),
-    [ $dbh->{pg_db}, $schema, $table3, '1', undef, 'dbd_pg_test3_index_c', 'hashed', 1, 'c', 'A', '0', '4', undef, 'c', '1' ],
+    [ $dbh->{pg_db}, $schema, $table3, '1', undef, 'dbd_pg_test3_index_c', 'hashed', 1, 'c', undef, '0', '4', undef, 'c', '1' ],
     [ $dbh->{pg_db}, $schema, $table3, undef, undef, undef, 'table', undef, undef, undef, '0', '0', undef, undef, undef ],
 ],
     three_uo => [
     ($with_include ? (
         [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_incl',    'btree',  1, 'b', 'A', '0', '1', undef, 'b', '1' ],
-        [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_incl',    'btree',  2, 'c', 'A', '0', '1', undef, 'c', '0' ],
+        [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_incl',    'btree',  2, 'c', undef, '0', '1', undef, 'c', '0' ],
     ) :()),
     [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_index_b', 'btree',  1, 'b', 'A', '0', '1', undef, 'b', '1' ],
     [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_pkey',    'btree',  1, 'a', 'A', '0', '1', undef, 'a', '1' ],

--- a/t/03dbmethod.t
+++ b/t/03dbmethod.t
@@ -917,7 +917,7 @@ is_deeply ($result, $expected, $t);
 
 my $with_oids = $pgversion < 120000 ? 'WITH OIDS' : '';
 my $with_include = $pgversion >= 110000;
-my $hash_index_idx = 4;
+my $hash_index_idx = 3;
 $hash_index_idx += 1 if $with_oids;
 $hash_index_idx += 2 if $with_include;
 ## Create some tables with various indexes
@@ -954,22 +954,21 @@ $hash_index_idx += 2 if $with_include;
 
 my $correct_stats = {
 one => [
-    [ $dbh->{pg_db}, $schema, $table1, undef, undef, undef, 'table', undef, undef, undef, '0', '0', undef, undef, undef ],
     [ $dbh->{pg_db}, $schema, $table1, '0', undef, 'dbd_pg_test1_index_c', 'btree',  1, 'c', 'A', '0', '1', undef, 'c', '1' ],
     [ $dbh->{pg_db}, $schema, $table1, '0', undef, 'dbd_pg_test1_pk',      'btree',  1, 'a', 'A', '0', '1', undef, 'a', '1' ],
     [ $dbh->{pg_db}, $schema, $table1, '0', undef, 'dbd_pg_test1_uc1',     'btree',  1, 'b', 'A', '0', '1', undef, 'b', '1' ],
+    [ $dbh->{pg_db}, $schema, $table1, undef, undef, undef, 'table', undef, undef, undef, '0', '0', undef, undef, undef ],
     ],
     two => [
-    [ $dbh->{pg_db}, $schema, $table2, undef, undef, undef, 'table', undef, undef, undef, '0', '0', undef, undef, undef ],
     [ $dbh->{pg_db}, $schema, $table2, '0', undef, 'dbd_pg_test2_b_key',   'btree',  1, 'b', 'A', '0', '1', undef, 'b', '1' ],
     [ $dbh->{pg_db}, $schema, $table2, '0', undef, 'dbd_pg_test2_b_key',   'btree',  2, 'c', 'A', '0', '1', undef, 'c', '1' ],
     [ $dbh->{pg_db}, $schema, $table2, '0', undef, 'dbd_pg_test2_pkey',    'btree',  1, 'a', 'A', '0', '1', undef, 'a', '1' ],
     [ $dbh->{pg_db}, $schema, $table2, '0', undef, 'dbd_pg_test2_pkey',    'btree',  2, 'b', 'A', '0', '1', undef, 'b', '1' ],
     [ $dbh->{pg_db}, $schema, $table2, '1', undef, 'dbd_pg_test2_expr',    'btree',  1, undef, 'A', '0', '1', undef, '(a + b)', '1' ],
     [ $dbh->{pg_db}, $schema, $table2, '1', undef, 'dbd_pg_test2_expr',    'btree',  2, 'c', 'A', '0', '1', undef, 'c', '1' ],
+    [ $dbh->{pg_db}, $schema, $table2, undef, undef, undef, 'table', undef, undef, undef, '0', '0', undef, undef, undef ],
     ],
     three => [
-    [ $dbh->{pg_db}, $schema, $table3, undef, undef, undef, 'table', undef, undef, undef, '0', '0', undef, undef, undef ],
     ($with_include ? (
         [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_incl',    'btree',  1, 'b', 'A', '0', '1', undef, 'b', '1' ],
         [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_incl',    'btree',  2, 'c', 'A', '0', '1', undef, 'c', '0' ],
@@ -979,6 +978,7 @@ one => [
     [ $dbh->{pg_db}, $schema, $table3, '0', undef, 'dbd_pg_test3_pred',    'btree',  1, 'c', 'A', '0', '1', '((c > 0) AND (c < 45))', 'c', '1' ],
     ($with_oids ? [ $dbh->{pg_db}, $schema, $table3, '1', undef, 'dbd_pg_test3_oid',     'btree',  1, 'oid', 'A', '0', '1', undef, 'oid', '1' ] : ()),
     [ $dbh->{pg_db}, $schema, $table3, '1', undef, 'dbd_pg_test3_index_c', 'hashed', 1, 'c', 'A', '0', '4', undef, 'c', '1' ],
+    [ $dbh->{pg_db}, $schema, $table3, undef, undef, undef, 'table', undef, undef, undef, '0', '0', undef, undef, undef ],
 ],
     three_uo => [
     ($with_include ? (
@@ -1001,7 +1001,7 @@ my @stats_columns = qw(
 
 ## 8.5 changed the way foreign key names are generated
 if ($pgversion >= 80500) {
-    $correct_stats->{two}[1][5] = $correct_stats->{two}[2][5] = 'dbd_pg_test2_b_c_key';
+    $correct_stats->{two}[0][5] = $correct_stats->{two}[1][5] = 'dbd_pg_test2_b_c_key';
 }
 
 my $stats;


### PR DESCRIPTION
The previous batch of `statistics_info` fixes was incomplete, and broke things on pre-8.3 servers.
As well as fixing that, this fixes the value the `ASC_OR_DESC` field, and adds a `pg_null_ordering` field.

A side-effect of the 8.3 fix that the table-level row is now last, instead of first, which might break order-sensitive users.  This new behaviour does however match the order implied by the DBI docs, and PostgreSQL's default NULL ordering.