### PR TITLE
Result length fix 1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dbdpg_test_*
 *.tar.gz
 cover_db/
 tarballs/
+*.swp

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3829,6 +3829,7 @@ AV * dbd_st_fetch (SV * sth, imp_sth_t * imp_sth)
                 else if (!SvROK(sv)) {
                     SvUTF8_on(sv);
                 }
+                SvSETMAGIC(sv);
             }
         }
     }

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -3828,8 +3828,8 @@ AV * dbd_st_fetch (SV * sth, imp_sth_t * imp_sth)
                 */
                 else if (!SvROK(sv)) {
                     SvUTF8_on(sv);
+                    SvSETMAGIC(sv);
                 }
-                SvSETMAGIC(sv);
             }
         }
     }


### PR DESCRIPTION
@turnstep Here's a new unit test that shows the length() bug and in a separate commit, one way I fixed it.

It seems like the string's length should be getting set here during each loop iteration:

sv_setpvn(sv, (char *)value, value_len);

Based on the earlier:

type_info->dequote(aTHX_ value, &value_len);

And dequote_string sure looks like it sets *value_len.

Something seems to be getting recycled behind the scenes.

perlguts(1) says:

> The "sv_set*()" functions are not generic enough to operate on values that have "magic".  See "Magic Virtual Tables" later in this document.
>
> Also note that the "sv_set*()" and "sv_cat*()" functions described earlier do not invoke 'set' magic on their targets.  This must be done by the user either by calling the "SvSETMAGIC()" macro after calling these functions, or by using one of the "sv_set*_mg()" or "sv_cat*_mg()" functions.

And that document always shows `SvUTF8_off(sv);` and `SvUTF8_on(sv);` followed immediately by `SvSETMAGIC(sv);`

Because of this?

```
PERL_MAGIC_utf8           vtbl_utf8      Cached UTF-8 information
```

So that's what I did and it works. That is done a few times in `Pg.xs` but seems like it may be needed in more places if this is the right fix.

I made another pull request in https://github.com/bucardo/dbdpg/pull/74 that solves the problem a different way, which may be more efficient, but I wonder if it may miss something because it wouldn't get run on all code paths, especially for future UTF-8 capable types.

Anyway, let me know what you think.