### PR TITLE
Automatically use 64-bit versions of large object functions when avallable

### DIFF
--- a/Changes
+++ b/Changes
@@ -22,6 +22,9 @@ Version ?? (unreleased)
  - Use non-root user when calling pg_resetwal
    [Greg Sabino Mullane]
 
+ - Automatically use 64-bit versions of large object functions when
+   available
+   [Dagfinn Ilmari Mannsåker, David Christensen]
 
 Version 3.15.0 (released May 21, 2021)
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -183,6 +183,9 @@ my $dbi_arch_dir;
 }
 
 my $defines = " -DPGLIBVERSION=$serverversion -DPGDEFPORT=$defaultport";
+if ($Config{ivsize} >= 8 && $serverversion >= 90300) {
+    $defines .= ' -DHAS64BITLO';
+}
 my $comp_opts = $Config{q{ccflags}} . $defines;
 
 if ($ENV{DBDPG_GCCDEBUG}) {

--- a/Pg.pm
+++ b/Pg.pm
@@ -2089,9 +2089,9 @@ location and C<undef> upon failure. This function cannot be used if AutoCommit i
 
 =item pg_lo_lseek64
 
-  $loc = $dbh->pg_lo_lseek64($lobj_fd, $offset, $whence);
-
-Same as pg_lo_lseek, but can handle much larger offsets and returned values. Requires Postgres 9.3 or greater.
+Backwards-compatibility alias for L</pg_lo_lseek>. Since DBD::Pg 3.16, that
+method handles 64-bit offsets if supported by the Perl and PostgreSQL versions
+in use.
 
 =item pg_lo_tell
 
@@ -2102,9 +2102,9 @@ This function cannot be used if AutoCommit is enabled.
 
 =item pg_lo_tell64
 
-  $loc = $dbh->pg_lo_tell64($lobj_fd);
-
-Same as pg_lo_tell, but can return much larger values. Requires Postgres 9.3 or greater.
+Backwards-compatibility alias for L</pg_lo_tell>. Since DBD::Pg 3.16, that
+method handles 64-bit offsets if supported by the Perl and PostgreSQL versions
+in use.
 
 =item pg_lo_truncate
 
@@ -2115,9 +2115,9 @@ This function cannot be used if AutoCommit is enabled.
 
 =item pg_lo_truncate64
 
-  $loc = $dbh->pg_lo_truncate64($lobj_fd, $len);
-
-Same as pg_lo_truncate, but can handle much larger lengths. Requires Postgres 9.3 or greater.
+Backwards-compatibility alias L</for pg_lo_truncate>. Since DBD::Pg 3.16, that
+method handles 64-bit offsets if supported by the Perl and PostgreSQL versions
+in use.
 
 =item pg_lo_close
 
@@ -4376,6 +4376,10 @@ The constants and their values are:
 DBD::Pg supports all largeobject functions provided by libpq via the
 C<< $dbh->pg_lo* >> methods. Please note that access to a large object, even read-only 
 large objects, must be put into a transaction.
+
+If DBD::Pg is compiled against and connected to PostgreSQL 9.3 or newer, and
+your Perl has 64-bit integers, it will use the 64-bit variants of the seek,
+tell and truncate methods.
 
 =head2 Cursors
 

--- a/Pg.xs
+++ b/Pg.xs
@@ -533,54 +533,33 @@ void
 pg_lo_lseek(dbh, fd, offset, whence)
     SV * dbh
     int fd
-    int offset
+    IV offset
     int whence
+    ALIAS:
+        pg_lo_lseek64 = 1
     CODE:
-        const int ret = pg_db_lo_lseek(dbh, fd, offset, whence);
+        const IV ret = pg_db_lo_lseek(dbh, fd, offset, whence);
         ST(0) = (ret >= 0) ? sv_2mortal(newSViv(ret)) : &PL_sv_undef;
-
-void
-pg_lo_lseek64(dbh, fd, offset, whence)
-    SV * dbh
-    int fd
-    unsigned int offset
-    int whence
-    CODE:
-        const unsigned int ret = pg_db_lo_lseek64(dbh, fd, offset, whence);
-        ST(0) = (ret >= 0) ? sv_2mortal(newSVuv(ret)) : &PL_sv_undef;
 
 void
 pg_lo_tell(dbh, fd)
     SV * dbh
     int fd
+    ALIAS:
+        pg_lo_tell64 = 1
     CODE:
-        const int ret = pg_db_lo_tell(dbh, fd);
+        const IV ret = pg_db_lo_tell(dbh, fd);
         ST(0) = (ret >= 0) ? sv_2mortal(newSViv(ret)) : &PL_sv_undef;
-
-void
-pg_lo_tell64(dbh, fd)
-    SV * dbh
-    int fd
-    CODE:
-        const unsigned int ret = pg_db_lo_tell64(dbh, fd);
-        ST(0) = (ret >= 0) ? sv_2mortal(newSVuv(ret)) : &PL_sv_undef;
 
 void
 pg_lo_truncate(dbh, fd, len)
     SV * dbh
     int fd
-    size_t len
+    UV len
+    ALIAS:
+        pg_lo_truncate64 = 1
     CODE:
-        const int ret = pg_db_lo_truncate(dbh, fd, len);
-        ST(0) = (ret >= 0) ? sv_2mortal(newSViv(ret)) : &PL_sv_undef;
-
-void
-pg_lo_truncate64(dbh, fd, len)
-    SV * dbh
-    int fd
-    unsigned int len
-    CODE:
-        const int ret = pg_db_lo_truncate64(dbh, fd, len);
+        const IV ret = pg_db_lo_truncate(dbh, fd, len);
         ST(0) = (ret >= 0) ? sv_2mortal(newSViv(ret)) : &PL_sv_undef;
 
 void

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -258,17 +258,11 @@ int pg_db_lo_read (SV *dbh, int fd, char *buf, size_t len);
 
 int pg_db_lo_write (SV *dbh, int fd, char *buf, size_t len);
 
-int pg_db_lo_lseek (SV *dbh, int fd, int offset, int whence);
+IV pg_db_lo_lseek (SV *dbh, int fd, IV offset, int whence);
 
-unsigned int pg_db_lo_lseek64 (SV *dbh, int fd, unsigned int offset, int whence);
+IV pg_db_lo_tell (SV *dbh, int fd);
 
-int pg_db_lo_tell (SV *dbh, int fd);
-
-unsigned int pg_db_lo_tell64 (SV *dbh, int fd);
-
-int pg_db_lo_truncate (SV *dbh, int fd, size_t len);
-
-int pg_db_lo_truncate64 (SV *dbh, int fd, unsigned int len);
+int pg_db_lo_truncate (SV *dbh, int fd, IV len);
 
 int pg_db_lo_unlink (SV *dbh, unsigned int lobjId);
 

--- a/t/03dbmethod.t
+++ b/t/03dbmethod.t
@@ -19,6 +19,7 @@ use Data::Dumper;
 use Test::More;
 use DBI     ':sql_types';
 use DBD::Pg ':pg_types';
+use Fcntl   ':seek';
 require 'dbdpg_test_setup.pl';
 select(($|=1,select(STDERR),$|=1)[1]);
 
@@ -1911,7 +1912,7 @@ like ($handle, qr/^[0-9]+$/o, $t);
 isnt ($object, -1, $t);
 
 $t='DB handle method "pg_lo_lseek" works when writing';
-$result = $dbh->pg_lo_lseek($handle, 0, 0);
+$result = $dbh->pg_lo_lseek($handle, 0, SEEK_SET);
 is ($result, 0, $t);
 isnt ($object, -1, $t);
 
@@ -1920,7 +1921,7 @@ SKIP: {
         skip 'Cannot test 64-bit version of largeobject functions unless Postgres is 9.3 or higher', 2;
     }
     $t='DB handle method "pg_lo_lseek64" works when writing';
-    $result = $dbh->pg_lo_lseek64($handle, 0, 0);
+    $result = $dbh->pg_lo_lseek64($handle, 0, SEEK_SET);
     is ($result, 0, $t);
     isnt ($object, -1, $t);
 }
@@ -1942,7 +1943,7 @@ like ($handle, qr/^[0-9]+$/o, $t);
 cmp_ok ($handle, 'eq', 0, $t);
 
 $t='DB handle method "pg_lo_lseek" works when reading';
-$result = $dbh->pg_lo_lseek($handle, 11, 0);
+$result = $dbh->pg_lo_lseek($handle, 11, SEEK_SET);
 is ($result, 11, $t);
 
 SKIP: {
@@ -1950,7 +1951,7 @@ SKIP: {
         skip 'Cannot test 64-bit version of largeobject functions unless Postgres is 9.3 or higher', 1;
     }
     $t='DB handle method "pg_lo_lseek64" works when reading';
-    $result = $dbh->pg_lo_lseek($handle, 11, 0);
+    $result = $dbh->pg_lo_lseek($handle, 11, SEEK_SET);
     is ($result, 11, $t);
 }
 
@@ -1968,7 +1969,7 @@ SKIP: {
 }
 
 $t='DB handle method "pg_lo_read" reads back the same data that was written';
-$dbh->pg_lo_lseek($handle, 0, 0);
+$dbh->pg_lo_lseek($handle, 0, SEEK_SET);
 my ($buf2,$data) = ('','');
 while ($dbh->pg_lo_read($handle, $data, 513)) {
     $buf2 .= $data;
@@ -1998,7 +1999,7 @@ SKIP: {
     is ($result, 0, $t);
 
     $t='DB handle method "pg_lo_truncate" truncates to expected size';
-    $dbh->pg_lo_lseek($handle, 0, 0);
+    $dbh->pg_lo_lseek($handle, 0, SEEK_SET);
     ($buf2,$data) = ('','');
     while ($dbh->pg_lo_read($handle, $data, 100)) {
         $buf2 .= $data;
@@ -2010,7 +2011,7 @@ SKIP: {
             skip 'Cannot test 64-bit version of largeobject functions unless Postgres is 9.3 or higher', 1;
         }
         $t='DB handle method "pg_lo_truncate64" truncates to expected size';
-        $dbh->pg_lo_lseek($handle, 0, 0);
+        $dbh->pg_lo_lseek($handle, 0, SEEK_SET);
         $result = $dbh->pg_lo_truncate64($handle, 22);
         ($buf2,$data) = ('','');
         while ($dbh->pg_lo_read($handle, $data, 100)) {
@@ -2146,7 +2147,7 @@ SKIP: {
 
     $t='DB handle method "pg_lo_lseek" fails with AutoCommit on';
     eval {
-        $dbh->pg_lo_lseek($handle, 0, 0);
+        $dbh->pg_lo_lseek($handle, 0, SEEK_SET);
     };
     like ($@, qr{pg_lo_lseek when AutoCommit is on}, $t);
 
@@ -2156,7 +2157,7 @@ SKIP: {
         }
         $t='DB handle method "pg_lo_lseek64" fails with AutoCommit on';
         eval {
-            $dbh->pg_lo_lseek64($handle, 0, 0);
+            $dbh->pg_lo_lseek64($handle, 0, SEEK_SET);
         };
         like ($@, qr{pg_lo_lseek64 when AutoCommit is on}, $t);
     }

--- a/t/03dbmethod.t
+++ b/t/03dbmethod.t
@@ -1942,30 +1942,73 @@ $handle = $dbh->pg_lo_open($object, $R);
 like ($handle, qr/^[0-9]+$/o, $t);
 cmp_ok ($handle, 'eq', 0, $t);
 
-$t='DB handle method "pg_lo_lseek" works when reading';
+$t='DB handle method "pg_lo_lseek(SEEK_SET)" works when reading';
 $result = $dbh->pg_lo_lseek($handle, 11, SEEK_SET);
 is ($result, 11, $t);
 
-SKIP: {
-    if ($pgversion < 90300 or $pglibversion < 90300) {
-        skip 'Cannot test 64-bit version of largeobject functions unless Postgres is 9.3 or higher', 1;
-    }
-    $t='DB handle method "pg_lo_lseek64" works when reading';
-    $result = $dbh->pg_lo_lseek($handle, 11, SEEK_SET);
-    is ($result, 11, $t);
-}
+$t='DB handle method "pg_lo_tell" works';
+my $tell_result = $dbh->pg_lo_tell($handle);
+is ($tell_result, $result, $t);
+
+$t='DB handle method "pg_lo_lseek(SEEK_CUR)" forward works when reading';
+$result = $dbh->pg_lo_lseek($handle, 11, SEEK_CUR);
+is ($result, 22, $t);
 
 $t='DB handle method "pg_lo_tell" works';
-$result = $dbh->pg_lo_tell($handle);
-is ($result, 11, $t);
+$tell_result = $dbh->pg_lo_tell($handle);
+is ($tell_result, $result, $t);
+
+$t='DB handle method "pg_lo_lseek(SEEK_CUR)" backward works when reading';
+$result = $dbh->pg_lo_lseek($handle, -10, SEEK_CUR);
+is ($result, 12, $t);
+
+$t='DB handle method "pg_lo_tell" works';
+$tell_result = $dbh->pg_lo_tell($handle);
+is ($tell_result, $result, $t);
+
+$t='DB handle method "pg_lo_lseek(SEEK_END)" works when reading';
+$result = $dbh->pg_lo_lseek($handle, -11, SEEK_END);
+is ($result, length($buf)-11, $t);
+
+$t='DB handle method "pg_lo_tell" works';
+$tell_result = $dbh->pg_lo_tell($handle);
+is ($tell_result, $result, $t);
 
 SKIP: {
     if ($pgversion < 90300 or $pglibversion < 90300) {
         skip 'Cannot test 64-bit version of largeobject functions unless Postgres is 9.3 or higher', 1;
     }
-    $t='DB handle method "pg_lo_tell64" works';
-    $result = $dbh->pg_lo_tell64($handle);
+    $t='DB handle method "pg_lo_lseek64(SEEK_SET)" works when reading';
+    $result = $dbh->pg_lo_lseek64($handle, 11, SEEK_SET);
     is ($result, 11, $t);
+
+    $t='DB handle method "pg_lo_tell64" works';
+    $tell_result = $dbh->pg_lo_tell64($handle);
+    is ($tell_result, $result, $t);
+
+    $t='DB handle method "pg_lo_lseek64(SEEK_CUR)" forward works when reading';
+    $result = $dbh->pg_lo_lseek64($handle, 11, SEEK_CUR);
+    is ($result, 22, $t);
+
+    $t='DB handle method "pg_lo_tell64" works';
+    $tell_result = $dbh->pg_lo_tell64($handle);
+    is ($tell_result, $result, $t);
+
+    $t='DB handle method "pg_lo_lseek64(SEEK_CUR)" backward works when reading';
+    $result = $dbh->pg_lo_lseek64($handle, -10, SEEK_CUR);
+    is ($result, 12, $t);
+
+    $t='DB handle method "pg_lo_tell64" works';
+    $tell_result = $dbh->pg_lo_tell64($handle);
+    is ($tell_result, $result, $t);
+
+    $t='DB handle method "pg_lo_lseek64(SEEK_END)" works when reading';
+    $result = $dbh->pg_lo_lseek64($handle, -11, SEEK_END);
+    is ($result, length($buf)-11, $t);
+
+    $t='DB handle method "pg_lo_tell64" works';
+    $tell_result = $dbh->pg_lo_tell64($handle);
+    is ($tell_result, $result, $t);
 }
 
 $t='DB handle method "pg_lo_read" reads back the same data that was written';

--- a/t/03dbmethod.t
+++ b/t/03dbmethod.t
@@ -26,7 +26,6 @@ my $dbh = connect_database();
 if (! $dbh) {
     plan skip_all => 'Connection to database failed, cannot continue testing';
 }
-plan tests => 646;
 
 my $superuser = is_super();
 
@@ -283,7 +282,7 @@ SKIP: {
     if ($pgversion < 80300) {
         $dbh->do("DROP TABLE $schema2.$table2");
         $dbh->do("DROP SEQUENCE $schema2.$sequence2");
-        skip ('Cannot test sequence rename on pre-8.3 servers', 2);
+        skip ('Cannot test sequence rename on pre-8.3 servers', 1);
     }
     $dbh->do("ALTER SEQUENCE $schema2.$sequence2 RENAME TO $sequence3");
     $dbh->commit();
@@ -304,7 +303,7 @@ SKIP: {
 }
 
 SKIP: {
-    skip('Cannot test GENERATED AS IDENTITY columns on pre-10 servers', 4)
+    skip('Cannot test GENERATED AS IDENTITY columns on pre-10 servers', 1)
         if $pgversion < 100000;
 
     for my $WHEN ('BY DEFAULT', 'ALWAYS') {
@@ -731,7 +730,7 @@ is ($sth->rows(), $total_temp-1, $t);
 SKIP: {
 
     if ($pgversion < 90300) {
-        skip ('Cannot test table_info for materialized views unless database if 9.3 or higher', 3);
+        skip ('Cannot test table_info for materialized views unless database if 9.3 or higher', 1);
     }
 
     $sth = $dbh->table_info(undef,undef,undef,'MATERIALIZED VIEW');
@@ -756,11 +755,11 @@ SKIP: {
 SKIP: {
 
     if ($pgversion < 90100) {
-        skip ('Cannot test table_info for foreign tables unless database is 9.1 or higher', 3);
+        skip ('Cannot test table_info for foreign tables unless database is 9.1 or higher', 1);
     }
 
     ## We can check for finer-grained access in more recent versions, but this is good enough:
-    $superuser or skip ('Cannot test foreign tables unless a superuser', 3);
+    $superuser or skip ('Cannot test foreign tables unless a superuser', 1);
 
     $sth = $dbh->table_info(undef,undef,undef,'FOREIGN TABLE');
     my $total_ftables = $sth->rows();
@@ -986,7 +985,7 @@ $dbh->do(qq{DROP TABLE $schema.$table});
 SKIP: {
 
     if ($pgversion < 80300) {
-        skip ('DB handle method column_info attribute "pg_enum_values" requires at least Postgres 8.3', 2);
+        skip ('DB handle method column_info attribute "pg_enum_values" requires at least Postgres 8.3', 1);
     }
 
     my @enumvalues = qw( foo bar baz buz );
@@ -1984,7 +1983,7 @@ $dbh->commit;
 SKIP: {
 
     if ($pglibversion < 80300 or $pgversion < 80300) {
-        skip ('Postgres version 8.3 or greater needed for pg_lo_truncate tests', 4);
+        skip ('Postgres version 8.3 or greater needed for pg_lo_truncate tests', 1);
     }
 
     $t='DB handle method "pg_lo_truncate" fails if opened in read mode only';
@@ -2032,14 +2031,14 @@ $dbh->rollback();
 
 SKIP: {
 
-    $superuser or skip ('Cannot run largeobject tests unless run as Postgres superuser', 40);
+    $superuser or skip ('Cannot run largeobject tests unless run as Postgres superuser', 1);
 
   SKIP: {
 
         eval {
             require File::Temp;
         };
-        $@ and skip ('Must have File::Temp to test pg_lo_import* and pg_lo_export', 13);
+        $@ and skip ('Must have File::Temp to test pg_lo_import* and pg_lo_export', 1);
 
         $t='DB handle method "pg_lo_import" works';
         my ($fh,$filename) = File::Temp::tmpnam();
@@ -2057,10 +2056,10 @@ SKIP: {
 
       SKIP: {
             if ($pglibversion < 80400) {
-                skip ('Cannot test pg_lo_import_with_oid unless compiled against 8.4 or better server', 5);
+                skip ('Cannot test pg_lo_import_with_oid unless compiled against 8.4 or better server', 1);
             }
             if ($pgversion < 80100) {
-                skip ('Cannot test pg_lo_import_with_oid against old versions of Postgres', 5);
+                skip ('Cannot test pg_lo_import_with_oid against old versions of Postgres', 1);
             }
 
             $t='DB handle method "pg_lo_import_with_oid" works with high number';
@@ -2070,7 +2069,7 @@ SKIP: {
             my $thandle;
           SKIP: {
 
-                skip ('Known bug: pg_log_import_with_oid throws an error. See RT #90448', 3);
+                skip ('Known bug: pg_log_import_with_oid throws an error. See RT #90448', 1);
 
                 $thandle = $dbh->pg_lo_import_with_oid($filename, $highnumber);
                 is ($thandle, $highnumber, $t);
@@ -2204,7 +2203,7 @@ SKIP: {
         eval {
             require File::Temp;
         };
-        $@ and skip ('Must have File::Temp to test pg_lo_import and pg_lo_export', 17);
+        $@ and skip ('Must have File::Temp to test pg_lo_import and pg_lo_export', 1);
 
         $t='DB handle method "pg_lo_import" works (AutoCommit on)';
         my ($fh,$filename) = File::Temp::tmpnam();
@@ -2342,7 +2341,7 @@ SKIP: {
     $t='DB handle method "pg_notifies" returns correct string length for recycled var';
 
     if ($pgversion < 90000) {
-        skip ('Cannot test notification payloads on pre-9.0 servers', 4);
+        skip ('Cannot test notification payloads on pre-9.0 servers', 1);
     }
 
     $dbh->do("LISTEN abc$notify_name");
@@ -2392,7 +2391,7 @@ $dbh->rollback();
 
 SKIP: {
     if ($DBI::VERSION < 1.54) {
-        skip ('DBI must be at least version 1.54 to test private_attribute_info', 2);
+        skip ('DBI must be at least version 1.54 to test private_attribute_info', 1);
     }
 
     $t='DB handle method "private_attribute_info" returns at least one record';
@@ -2434,7 +2433,7 @@ my $mtvar; ## This is an implicit test of getcopydata: please leave this var und
 SKIP: {
 
     if ($pgversion < 80300) {
-        skip ('Cannot test pg_ping via COPY on pre-8.3 servers', 20);
+        skip ('Cannot test pg_ping via COPY on pre-8.3 servers', 1);
     }
 
     for my $type (qw/ ping pg_ping /) {
@@ -2484,7 +2483,7 @@ SKIP: {
 
       SKIP: {
 
-        skip 'Cannot safely reopen sockets on Win32', 2 if $^O =~ /Win32/;
+        skip 'Cannot safely reopen sockets on Win32', 1 if $^O =~ /Win32/;
 
         $val = $type eq 'ping' ? 0 : -3;
         $t=qq{DB handle method "$type" returns $val after a lost network connection (outside transaction)};
@@ -2517,6 +2516,7 @@ $t=q{DB handle method "pg_type_info" returns 12 for type 123 (PrintError on)};
 is ($dbh->pg_type_info(123), 12, $t);
 $dbh->{PrintError} = 0;
 
+done_testing();
 
 exit;
 


### PR DESCRIPTION

This mostly reverts commit 751f5ca5ef664f0af5934db34d7e217cd4a61376 and replaces it with an approach originally submitted by @pgguru in 2017. The 64-suffixed method names are retained as backwards compatibility aliases.

Also add tests for LOs of size INT_MAX and larger. Large objects are stored sparsely, so this doesn't actually take any significant space in the database.

In passing, convert the test script to use `done_testing()`.
