### PR TITLE
Fix reading binary data from ParamValues

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1146,7 +1146,7 @@ SV * dbd_st_FETCH_attrib (SV * sth, imp_sth_t * imp_sth, SV * keysv)
                     }
                 }
                 else {
-                    val = newSVpv(currph->value,0);
+                    val = newSVpv(currph->value,currph->valuelen);
                     if (!hv_store_ent(pvhv, key, val, 0)) {
                         SvREFCNT_dec(val);
                     }

--- a/t/02attribs.t
+++ b/t/02attribs.t
@@ -18,7 +18,7 @@ my (undef,undef,$dbh) = connect_database();
 if (! $dbh) {
     plan skip_all => 'Connection to database failed, cannot continue testing';
 }
-plan tests => 284;
+plan tests => 285;
 
 isnt ($dbh, undef, 'Connect to database for handle attributes testing');
 
@@ -855,6 +855,14 @@ $t='Statement handle attribute "ParamValues" works after execute';
 $sth->execute();
 $attrib = $sth->{ParamValues};
 is_deeply ($attrib, $expected, $t);
+
+$t='Statement handle attribute "ParamValues" works with NULL-embedded strings';
+my $tvalue = "aaa\000bbb"; # binary data with \0
+$sth = $dbh->prepare('INSERT INTO dbd_pg_test (id, val, pname) VALUES (?, ?, "")');
+$sth->bind_param(1, 1234);
+$sth->bind_param(2, $tvalue, {pg_type => PG_BYTEA});
+$attrib = $sth->{ParamValues};
+is ($attrib->{2}, $tvalue);
 
 #
 # Test of the statement handle attribute "ParamTypes"


### PR DESCRIPTION
In our DBI plugin that make DB reconnect seamless for an end user, we transfer current to-be executed query parameters from an old connection to the new one[0]. But this fails in case when some data in parameters was binary. This PR fixes this case by not relying on strlen() calculations but using already known string length instead.

[0] https://metacpan.org/dist/DBIx-RetryOverDisconnects/source/lib/DBIx/RetryOverDisconnects.pm#L550