### PR TITLE
Adding an option to return SQL_INT8 as a number or as a string

### DIFF
--- a/Pg.pm
+++ b/Pg.pm
@@ -1587,6 +1587,7 @@ use 5.008001;
         return {
                 pg_async_status                => undef,
                 pg_bool_tf                     => undef,
+                pg_int8_as_string              => undef,
                 pg_db                          => undef,
                 pg_default_port                => undef,
                 pg_enable_utf8                 => undef,
@@ -3294,6 +3295,15 @@ Note that the value of client_encoding is only checked on connection time. If
 you change the client_encoding to/from 'UTF8' after connecting, you can set 
 pg_enable_utf8 to -1 to force DBD::Pg to read in the new client_encoding and 
 act accordingly.
+
+=head3 B<pg_int8_as_string> (integer)
+
+DBD::Pg specific attribute. Since version 3.0.0 the processing of SQL_INT8 has
+changed, before that 64 bit values were returned as strings, starting from
+version 3.0.0 64 bit values are returned as numbers. This flag makes it
+possible to return the old behavior. The old behavior is useful when encoding
+the results of a call in JSON format and passing it to JavaScript for
+processing, where integer values have a precision of no more than 53 bits.
 
 =head3 B<pg_errorlevel> (integer)
 

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -34,6 +34,7 @@ struct imp_dbh_st {
 
 
     bool    pg_bool_tf;        /* do bools return 't'/'f'? Set by user, default is 0 */
+    bool    pg_int8_as_string; /* Return bigint values as string values always, default is 0 */
     bool    prepare_now;       /* force immediate prepares, even with placeholders. Set by user, default is 0 */
     bool    done_begin;        /* have we done a begin? (e.g. are we in a transaction?) */
     bool    dollaronly;        /* only consider $1, $2 ... as valid placeholders */


### PR DESCRIPTION
In versions prior to 3.0.0, values of type SQL_INT8 were returned as strings, in some cases it was convenient, for example, when passing returned values to a web browser, since in JavaScript the integer type is 53 bits.
The pg_int8_as_string option, when true, returns the old behavior and returns 64-bit integer values as strings (default is false).