### PR TITLE
Fixed hangup of execution of queries like "COPY TO STDIN" in asynchronous mode.

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5318,6 +5318,9 @@ long pg_db_result (SV *h, imp_dbh_t *imp_dbh)
             TRACE_PQCLEAR;
             PQclear(result);
         }
+        if ( rows == -1 ) {
+            break;
+        }
     }
 
     if (NULL != imp_dbh->async_sth) {


### PR DESCRIPTION
The problem is in the wrong sequence of calls when processing the result of calling the COPY command in asynchronous mode.
https://github.com/bucardo/dbdpg/issues/98

The problem is that the pg_db_result method tries to get the result of the query before it completes. The result of the COPY command will be only after the end of reading / writing the data stream.

Perhaps the problem can be solved differently, I did not want to change the source code much.