### PR TITLE
Allow MYMETA.* files to be generated

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -232,7 +232,6 @@ my %opts =
      PERL_MALLOC_OK => 1,
      NEEDS_LINKING  => 1,
      NO_META        => 1,
-     NO_MYMETA      => 0,
      NORECURS       => 1,
      PM             => {
                         'Pg.pm' => '$(INST_LIBDIR)/Pg.pm',


### PR DESCRIPTION
These files are needed for installation via App::cpm. See
https://github.com/skaji/cpm/issues/234 This reverts a change which was
introduced in 7856005dd7437ef7b0
