### PR TITLE
Issue #104: Fix tests failing when root's shell is not a Bourne shell

### DIFF
--- a/t/dbdpg_test_setup.pl
+++ b/t/dbdpg_test_setup.pl
@@ -407,7 +407,7 @@ version: $version
                 $olddir = getcwd;
                 eval {
                     chdir $testdir;
-                    $info = qx{su -m $testuser -c "$initdb --locale=C -E UTF8 -D $testdir/data 2>&1"};
+                    $info = qx{su -m $testuser -c "/bin/sh -c '$initdb --locale=C -E UTF8 -D $testdir/data 2>&1'"};
                 };
                 my $err = $@;
                 chdir $olddir;


### PR DESCRIPTION
This PR addresses issue #104 by forcing the test suite's `initdb` command to execute in a Bourne shell.