### PR TITLE
Update CI workflow to test on Perl 5.40

### DIFF
--- a/.github/workflows/with_pg.yaml
+++ b/.github/workflows/with_pg.yaml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        perl: [ '5.30', '5.36' ]
+        perl: [ '5.30', '5.36', '5.40' ]
         postgres: [ '11', '13', 'latest' ]
 
     services:


### PR DESCRIPTION
This trivial PR adds Perl 5.40 to the GitHub Actions CI workflow.