### PR TITLE
08async fixes

### DIFF
--- a/t/08async.t
+++ b/t/08async.t
@@ -18,7 +18,7 @@ if (! $dbh) {
     plan skip_all => 'Connection to database failed, cannot continue testing';
 }
 
-plan tests => 67;
+plan tests => 66;
 
 isnt ($dbh, undef, 'Connect to database for async testing');
 

--- a/t/08async.t
+++ b/t/08async.t
@@ -103,7 +103,7 @@ eval {
 like ($@, qr{No async}, $t);
 
 $res = $dbh->do('SELECT 123', {pg_async => PG_ASYNC});
-$t=q{Method pg_ready() works after a non-async query};
+$t=q{Method pg_ready() works after async query};
 ## Sleep a sub-second to make sure the server has caught up
 sleep 0.2;
 eval {

--- a/t/08async.t
+++ b/t/08async.t
@@ -118,8 +118,6 @@ $res = $dbh->pg_ready();
 $t=q{Database method pg_ready() returns true when called a second time};
 is ($res, 1, $t);
 
-$t=q{Database method pg_ready() returns 1 after a completed async do()};
-is ($res, 1, $t);
 $t=q{Cancelling an async do() query works };
 eval {
     $res = $dbh->pg_cancel();


### PR DESCRIPTION
This fixes three minor mistakes in t/08async.t I found while testing my async-prepare changes:

Test #20 says "Method pg_ready() works after a non-async query", should be async as an async query was started.
Test #23 is a duplicate of test #21.
As test #23 is a duplicate of test #21, there are only 66 tests in this file and not 67.