### PR TITLE
Proposed cancel changes.

### DIFF
--- a/Pg.pm
+++ b/Pg.pm
@@ -166,6 +166,7 @@ use 5.008001;
             DBD::Pg::db->install_method('pg_result'); ## NOT duplicated below!
             DBD::Pg::db->install_method('pg_rollback_to');
             DBD::Pg::db->install_method('pg_savepoint');
+            DBD::Pg::db->install_method('pg_send_cancel');
             DBD::Pg::db->install_method('pg_server_trace');
             DBD::Pg::db->install_method('pg_server_untrace');
             DBD::Pg::db->install_method('pg_type_info');

--- a/Pg.pm
+++ b/Pg.pm
@@ -4209,6 +4209,14 @@ that would have been returned by the asynchronous L</do> or L</execute> if it ha
 
   $result = $dbh->pg_result;
 
+=item B<pg_send_cancel>
+
+Send a request to cancel a running asynchronous query to the
+server. Returns true if this succeeded, false otherwise. The actual
+outcome of the query still needs to be determined in the ordinary
+way. If a running query was actually cancelled, C<pg_result> will
+return zero and the C<state> method will return 57014.
+
 =back
 
 =head3 Asynchronous Examples

--- a/Pg.xs
+++ b/Pg.xs
@@ -869,6 +869,13 @@ pg_ready(dbh)
         ST(0) = sv_2mortal(newSViv(pg_db_ready(dbh, imp_dbh)));
 
 void
+pg_send_cancel(dbh)
+    SV *dbh
+    CODE:
+    D_imp_dbh(dbh);
+    ST(0) = pg_db_send_cancel(dbh, imp_dbh) ? &PL_sv_yes : &PL_sv_no;
+
+void
 pg_cancel(dbh)
     SV *dbh
     CODE:

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5552,10 +5552,13 @@ static int handle_old_async(pTHX_ SV * handle, imp_dbh_t * imp_dbh, const int as
                 TRACE_PQCLEAR;
                 PQclear(result);
             }
-            /* We need to rollback! - reprepare!? */
-            TRACE_PQEXEC;
-            PQexec(imp_dbh->conn, "rollback");
-            imp_dbh->done_begin = DBDPG_FALSE;
+
+            if (PQTRANS_IDLE != pg_db_txn_status(aTHX_ imp_dbh)) {
+                /* We need to rollback! - reprepare!? */
+                TRACE_PQEXEC;
+                PQexec(imp_dbh->conn, "rollback");
+                imp_dbh->done_begin = DBDPG_FALSE;
+            }
         }
     }
     else if (asyncflag & PG_OLDQUERY_WAIT) {

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5448,12 +5448,6 @@ int pg_db_cancel(SV *h, imp_dbh_t *imp_dbh)
         return DBDPG_FALSE;
     }
 
-    if (-1 == imp_dbh->async_status) {
-        pg_error(aTHX_ h, PGRES_FATAL_ERROR, "Asychronous query has already been cancelled");
-        if (TEND_slow) TRC(DBILOGFP, "%sEnd pg_db_cancel (error: async cancelled)\n", THEADER_slow);
-        return DBDPG_FALSE;
-    }
-
     /* Get the cancel structure */
     TRACE_PQGETCANCEL;
     cancel = PQgetCancel(imp_dbh->conn);
@@ -5545,7 +5539,7 @@ static int handle_old_async(pTHX_ SV * handle, imp_dbh_t * imp_dbh, const int as
             imp_dbh->done_begin = DBDPG_FALSE;
         }
     }
-    else if (asyncflag & PG_OLDQUERY_WAIT || imp_dbh->async_status == -1) {
+    else if (asyncflag & PG_OLDQUERY_WAIT) {
         /* Finish up the outstanding query and throw out the result, unless an error */
         if (TRACE3_slow) { TRC(DBILOGFP, "%sWaiting for old async command to finish\n", THEADER_slow); }
         TRACE_PQGETRESULT;

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5455,7 +5455,7 @@ int pg_db_cancel(SV *h, imp_dbh_t *imp_dbh)
     cancel = PQgetCancel(imp_dbh->conn);
 
     /* This almost always works. If not, free our structure and complain loudly */
-    TRACE_PQGETCANCEL;
+    TRACE_PQCANCEL;
     if (! PQcancel(cancel,errbuf,sizeof(errbuf))) {
         TRACE_PQFREECANCEL;
         PQfreeCancel(cancel);
@@ -5640,7 +5640,7 @@ int dbd_st_cancel(SV *sth, imp_sth_t *imp_sth)
     cancel = PQgetCancel(imp_dbh->conn);
 
     /* This almost always works. If not, free our structure and complain loudly */
-    TRACE_PQGETCANCEL;
+    TRACE_PQCANCEL;
     if (!PQcancel(cancel, errbuf, sizeof(errbuf))) {
         TRACE_PQFREECANCEL;
         PQfreeCancel(cancel);

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5333,6 +5333,12 @@ long pg_db_result (SV *h, imp_dbh_t *imp_dbh)
             pg_error(aTHX_ h, status, PQerrorMessage(imp_dbh->conn));
             break;
         case PGRES_FATAL_ERROR:
+            /* query cancelled? */
+            if (0 == strncmp(imp_dbh->sqlstate, "57014", 5)) {
+                rows = 0;
+                break;
+            }
+
         default:
             rows = -2;
             TRACE_PQERRORMESSAGE;

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -278,6 +278,8 @@ long pg_db_result (SV *h, imp_dbh_t *imp_dbh);
 
 int pg_db_ready(SV *h, imp_dbh_t *imp_dbh);
 
+int pg_db_send_cancel (SV *h, imp_dbh_t *imp_dbh);
+
 int pg_db_cancel (SV *h, imp_dbh_t *imp_dbh);
 
 int pg_db_cancel_sth (SV *sth, imp_sth_t *imp_sth);

--- a/t/02attribs.t
+++ b/t/02attribs.t
@@ -1065,11 +1065,11 @@ is ($sth->{pg_async_status}, 1, $t);
 $t=q{Database handle attribute "pg_async_status" returns a 1 after an asynchronous execute};
 is ($dbh->{pg_async_status}, 1, $t);
 
-$t=q{Statement handle attribute "pg_async_status" returns a -1 after a cancel};
+$t=q{Statement handle attribute "pg_async_status" returns a 0 after a cancel};
 $dbh->pg_cancel();
-is ($sth->{pg_async_status}, -1, $t);
-$t=q{Database handle attribute "pg_async_status" returns a -1 after a cancel};
-is ($dbh->{pg_async_status}, -1, $t);
+is ($sth->{pg_async_status}, 0, $t);
+$t=q{Database handle attribute "pg_async_status" returns a 0 after a cancel};
+is ($dbh->{pg_async_status}, 0, $t);
 sleep 3;
 
 #

--- a/t/08async.t
+++ b/t/08async.t
@@ -12,7 +12,7 @@ use DBD::Pg ':async';
 require 'dbdpg_test_setup.pl';
 select(($|=1,select(STDERR),$|=1)[1]);
 
-my $dbh = connect_database();
+my $dbh = connect_database({AutoCommit => 1});
 
 if (! $dbh) {
     plan skip_all => 'Connection to database failed, cannot continue testing';
@@ -349,7 +349,6 @@ $t=q{Method fetchall_arrayref returns correct result after pg_result};
 is_deeply ($res, [[123]], $t);
 
 $dbh->do('CREATE TABLE dbd_pg_test5(id INT, t TEXT)');
-$dbh->commit();
 $sth->execute();
 
 $t=q{Method prepare() works when passed in PG_OLDQUERY_CANCEL};

--- a/t/08async.t
+++ b/t/08async.t
@@ -82,9 +82,9 @@ is ($@, q{}, $t);
 $t=q{Database method pg_cancel returns a false value when cancellation works but finished};
 is ($res, q{}, $t);
 
-$t=q{Database attribute "async_status" returns -1 after pg_cancel};
+$t=q{Database attribute "async_status" returns 0 after pg_cancel};
 $res = $dbh->{pg_async_status};
-is ($res, -1, $t);
+is ($res, 0, $t);
 
 $t=q{Running do() after a cancelled query works};
 eval {
@@ -309,8 +309,8 @@ like ($@, qr{previous async}, $t);
 
 $dbh->pg_cancel;
 
-$t=q{Directly after pg_cancel(), pg_async_status is -1};
-is ($dbh->{pg_async_status}, -1, $t);
+$t=q{Directly after pg_cancel(), pg_async_status is 0};
+is ($dbh->{pg_async_status}, 0, $t);
 
 $t=q{Method execute() works when prepare has PG_ASYNC flag};
 $sth->execute();


### PR DESCRIPTION
Splits `pg_db_cancel ` into a sychronous cancel operation callled `pg_db_cancel` and a function which just sends a cancel request to the server without waiting for the result called `pg_db_send_cancel`. Fixes the cancel result handling code in `pg_db_cancel` by invoking `pg_db_result` to wait for the result of the possibly cancelled query instead of partially duplicating the result handling code in `pg_db_cancel` itself.

Introduces a new internal function called `do_send_cancel` which contains just the cancel request sending logic and calls that from all places in the original code which used to duplicate this functionality.

Changes `pg_db_result` such that it no longer treats cancelled queries as fatal errors but returns zero and a SQLSTATE of 57014 instead.

Modifies t/08async.t to enable AutoCommit so that cancelled queries no longer cause transaction aborts which would need to be dealt with by rollbacks. Removes a now redundant `$dbh->commit()`. Changes `handle_old_async` cancel path to only issue a rollback if actually in a transaction to avoid warnings about issueing a rollback outside of a transaction.

Unrelated fix: Uses the correct TRACE macro (`TRACE_PQCANCEL`) when about to call `PQcancel` instead of the `TRACE_PQGETCANCEL` which was used in this place instead.

_This passes the test suite plus the two tests I added for_ `pg_db_send_cancel`. 

