### PR TITLE
C23 compliance.

### DIFF
--- a/quote.c
+++ b/quote.c
@@ -183,13 +183,13 @@ char * quote_circle(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int es
 }
 
 
-char * quote_bytea(pTHX_ char *string, STRLEN len, STRLEN *retlen, int estring)
+char * quote_bytea(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring)
 {
     char * result;
     STRLEN oldlen = len;
 
     /* For this one, always use the E'' format if we can */
-    result = string;
+    result = (char *)string;
     (*retlen) = 2;
     while (len > 0) {
         if (*string == '\'') {
@@ -311,7 +311,7 @@ char * quote_int(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estri
     return result;
 }
 
-char * quote_float(pTHX_ char *string, STRLEN len, STRLEN *retlen, int estring)
+char * quote_float(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring)
 {
     char * result;
 
@@ -413,21 +413,21 @@ char * quote_name(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estr
     return result;
 }
 
-void dequote_char(pTHX_ const char *string, STRLEN *retlen, int estring)
+void dequote_char(pTHX_ char *string, STRLEN *retlen)
 {
     /* TODO: chop_blanks if requested */
     *retlen = strlen(string);
 }
 
 
-void dequote_string(pTHX_ const char *string, STRLEN *retlen, int estring)
+void dequote_string(pTHX_ char *string, STRLEN *retlen)
 {
     *retlen = strlen(string);
 }
 
 
 
-static void _dequote_bytea_escape(char *string, STRLEN *retlen, int estring)
+static void _dequote_bytea_escape(char *string, STRLEN *retlen)
 {
     char *result;
 
@@ -476,7 +476,7 @@ static int _decode_hex_digit(char digit)
     return -1;
 }
 
-static void _dequote_bytea_hex(char *string, STRLEN *retlen, int estring)
+static void _dequote_bytea_hex(char *string, STRLEN *retlen)
 {
     char *result;
 
@@ -499,14 +499,14 @@ static void _dequote_bytea_hex(char *string, STRLEN *retlen, int estring)
     }
 }
 
-void dequote_bytea(pTHX_ char *string, STRLEN *retlen, int estring)
+void dequote_bytea(pTHX_ char *string, STRLEN *retlen)
 {
 
     if (NULL != string) {
         if ('\\' == *string && 'x' == *(string+1))
-            _dequote_bytea_hex(string, retlen, estring);
+            _dequote_bytea_hex(string, retlen);
         else
-            _dequote_bytea_escape(string, retlen, estring);
+            _dequote_bytea_escape(string, retlen);
     }
 }
 
@@ -515,19 +515,19 @@ void dequote_bytea(pTHX_ char *string, STRLEN *retlen, int estring)
     it might be nice to let people go the other way too. Say when talking
     to something that uses SQL_BINARY
  */
-void dequote_sql_binary(pTHX_ char *string, STRLEN *retlen, int estring)
+void dequote_sql_binary(pTHX_ char *string, STRLEN *retlen)
 {
 
     /* We are going to return a dequote_bytea(), just in case */
     warn("Use of SQL_BINARY invalid in dequote()");
-    dequote_bytea(aTHX_ string, retlen, estring);
+    dequote_bytea(aTHX_ string, retlen);
 
     /* Put dequote_sql_binary function here at some point */
 }
 
 
 
-void dequote_bool(pTHX_ char *string, STRLEN *retlen, int estring)
+void dequote_bool(pTHX_ char *string, STRLEN *retlen)
 {
 
     switch(*string){
@@ -540,7 +540,7 @@ void dequote_bool(pTHX_ char *string, STRLEN *retlen, int estring)
 }
 
 
-void null_dequote(pTHX_ const char *string, STRLEN *retlen, int estring)
+void null_dequote(pTHX_ char *string, STRLEN *retlen)
 {
     *retlen = strlen(string);
 

--- a/quote.h
+++ b/quote.h
@@ -1,20 +1,20 @@
 
 char * null_quote(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring);
 char * quote_string(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring);
-char * quote_bytea(pTHX_ char *string, STRLEN len, STRLEN *retlen, int estring);
+char * quote_bytea(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring);
 char * quote_sql_binary(pTHX_ char *string, STRLEN len, STRLEN *retlen, int estring);
 char * quote_bool(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring);
 char * quote_integer(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring);
 char * quote_int(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring);
-char * quote_float(pTHX_ char *string, STRLEN len, STRLEN *retlen, int estring);
+char * quote_float(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring);
 char * quote_name(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring);
 char * quote_geom(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring);
 char * quote_path(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring);
 char * quote_circle(pTHX_ const char *string, STRLEN len, STRLEN *retlen, int estring);
-void dequote_char(pTHX_ const char *string, STRLEN *retlen, int estring);
-void dequote_string(pTHX_ const char *string, STRLEN *retlen, int estring);
-void dequote_bytea(pTHX_ char *string, STRLEN *retlen, int estring);
-void dequote_sql_binary(pTHX_ char *string, STRLEN *retlen, int estring);
-void dequote_bool(pTHX_ char *string, STRLEN *retlen, int estring);
-void null_dequote(pTHX_ const char *string, STRLEN *retlen, int estring);
+void dequote_char(pTHX_ char *string, STRLEN *retlen);
+void dequote_string(pTHX_ char *string, STRLEN *retlen);
+void dequote_bytea(pTHX_ char *string, STRLEN *retlen);
+void dequote_sql_binary(pTHX_ char *string, STRLEN *retlen);
+void dequote_bool(pTHX_ char *string, STRLEN *retlen);
+void null_dequote(pTHX_ char *string, STRLEN *retlen);
 bool is_keyword(const char *string);

--- a/types.c
+++ b/types.c
@@ -603,8 +603,8 @@ typedef struct sql_type_info {
     bool    bind_ok;
     char    array_delimiter;
     char*   arrayout;
-    char*   (*quote)();
-    void    (*dequote)();
+    char*   (*quote)(pTHX_ const char *, STRLEN, STRLEN *, int);
+    void    (*dequote)(pTHX_ char *, STRLEN *);
     union   {
             int pg;
             int sql;

--- a/types.h
+++ b/types.h
@@ -8,8 +8,8 @@ typedef struct sql_type_info {
     bool    bind_ok;
     char    array_delimiter;
     char*   arrayout;
-    char*   (*quote)();
-    void    (*dequote)();
+    char*   (*quote)(pTHX_ const char *, STRLEN, STRLEN *, int);
+    void    (*dequote)(pTHX_ char *, STRLEN *);
     union   {
             int pg;
             int sql;


### PR DESCRIPTION
C23 eliminates the historical K&R syntax `void function()` to declare a function taking any number of arguments, making `void function()` equivalent to `void function(void)`. Because of this, types.h can no longer be compiled with a C23 compilers.

I've changed the function pointers to include prototypes and the quote/ dequote functions accordingly. I've updated the Perl code in types.c despite it doesn't seem to work anymore. While at that, I've also removed the unused estring argument from the dequote functions as the dbdimp.c code doesn't pass that, anyway.