### PR TITLE
paths-ignore "what it was likely meant to become"

### DIFF
--- a/.github/workflows/with_pg.yaml
+++ b/.github/workflows/with_pg.yaml
@@ -2,10 +2,12 @@ name: CI in Docker container
 
 on:
   push:
+    paths-ignore:
+      - 'testme.tmp.pl'
   pull_request:
+    paths-ignore:
+      - 'testme.tmp.pl'
   workflow_dispatch:
-  paths-ignore:
-    - 'testme.tmp.pl'
 #  schedule:
 #    - cron: '42 5 * * *'
 


### PR DESCRIPTION
Precondition for getting the 5.30  CI tests working again:

Commit 44534664952ab660064e9bbb1dd91dbbb439c331 added a `paths-ignore` element to the `on:` section of _with_pg.yaml_.  Unfortunately, the syntax used for this was wrong as `paths-ignore` is a subelement of `on.<push|pull_request|pull_request_target>`, see

https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#onpushpull_requestpull_request_targetpathspaths-ignore

Because of this, trying to run this action manually via the GitHub web UI silently fails.

This PR fixes the syntax based on my best guess what this `paths-ignore` was meant to become (don't run action automatically if only _testme.tmp.pl_ was changed).