### PR TITLE
added ExtUtils::MakeMaker 7.64 to configure_requires

### DIFF
--- a/META.json
+++ b/META.json
@@ -47,6 +47,7 @@
    ],
    "configure_requires" : {
       "DBI" : "1.614",
+       "ExtUtils::MakeMaker" : "7.64",
       "version" : "0"
    },
    "license" : "perl",

--- a/META.yml
+++ b/META.yml
@@ -21,6 +21,7 @@ build_requires:
   version                   : 0
 configure_requires:
   DBI                       : 1.614
+  ExtUtils::MakeMaker       : 7.64
   version                   : 0
 recommends:
   Cwd                       : 0


### PR DESCRIPTION
Added a configure_requires depenency on ExtUtils::MakeMaker 7.64 to META.json and META.yml so that `perl Makefile.PL` again works with Perl 5.30 because cpanm will now update MakeMaker if the version included with a particular perl version is too old.