### PR TITLE
updated copyright end years to stop 99_lint.t tests from failing

### DIFF
--- a/Pg.h
+++ b/Pg.h
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2000-2025 Greg Sabino Mullane and others: see the Changes file
+   Copyright (c) 2000-2026 Greg Sabino Mullane and others: see the Changes file
    Copyright (c) 1997-2000 Edmund Mergl
    Portions Copyright (c) 1994-1997 Tim Bunce
 

--- a/Pg.pm
+++ b/Pg.pm
@@ -1,6 +1,6 @@
 #  -*-cperl-*-
 #
-#  Copyright (c) 2002-2025 Greg Sabino Mullane and others: see the Changes file
+#  Copyright (c) 2002-2026 Greg Sabino Mullane and others: see the Changes file
 #  Portions Copyright (c) 2002 Jeffrey W. Baker
 #  Portions Copyright (c) 1997-2001 Edmund Mergl
 #  Portions Copyright (c) 1994-1997 Tim Bunce
@@ -4576,7 +4576,7 @@ Visit the archives at http://grokbase.com/g/perl/dbd-pg
 
 =head1 COPYRIGHT AND LICENSE
 
-Copyright (C) 1994-2025, Greg Sabino Mullane
+Copyright (C) 1994-2026, Greg Sabino Mullane
 
 This module (DBD::Pg) is free software; you can redistribute it and/or modify it 
 under the same terms as Perl 5.10.0. For more details, see the full text of the 

--- a/Pg.xs
+++ b/Pg.xs
@@ -1,6 +1,6 @@
 /*
 
-  Copyright (c) 2000-2025 Greg Sabino Mullane and others: see the Changes file
+  Copyright (c) 2000-2026 Greg Sabino Mullane and others: see the Changes file
   Portions Copyright (c) 1997-2000 Edmund Mergl
   Portions Copyright (c) 1994-1997 Tim Bunce
 

--- a/README
+++ b/README
@@ -1,5 +1,5 @@
 
-DBD::Pg is Copyright (C) 1994-2025, Greg Sabino Mullane
+DBD::Pg is Copyright (C) 1994-2026, Greg Sabino Mullane
 
 DBD::Pg  --  the DBI PostgreSQL interface for Perl
 
@@ -392,7 +392,7 @@ Once this is done, 'make test' succeeds properly.
 COPYRIGHT:
 ----------
 
-	Copyright (c) 2002-2025 Greg Sabino Mullane and others: see the Changes file
+	Copyright (c) 2002-2026 Greg Sabino Mullane and others: see the Changes file
 	Portions Copyright (c) 2002 Jeffrey W. Baker
 	Portions Copyright (c) 1997-2001 Edmund Mergl
 	Portions Copyright (c) 1994-1997 Tim Bunce

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -1,6 +1,6 @@
 /*
 
-  Copyright (c) 2002-2025 Greg Sabino Mullane and others: see the Changes file
+  Copyright (c) 2002-2026 Greg Sabino Mullane and others: see the Changes file
   Portions Copyright (c) 2002 Jeffrey W. Baker
   Portions Copyright (c) 1997-2000 Edmund Mergl
   Portions Copyright (c) 1994-1997 Tim Bunce

--- a/dbdimp.h
+++ b/dbdimp.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2000-2025 Greg Sabino Mullane and others: see the Changes file
+    Copyright (c) 2000-2026 Greg Sabino Mullane and others: see the Changes file
     Portions Copyright (c) 1997-2000 Edmund Mergl
     Portions Copyright (c) 1994-1997 Tim Bunce
     

--- a/quote.c
+++ b/quote.c
@@ -1,6 +1,6 @@
 /*
 
-   Copyright (c) 2003-2025 Greg Sabino Mullane and others: see the Changes file
+   Copyright (c) 2003-2026 Greg Sabino Mullane and others: see the Changes file
 
    You may distribute under the terms of either the GNU General Public
    License or the Artistic License, as specified in the Perl README file.

--- a/types.c
+++ b/types.c
@@ -1,6 +1,6 @@
 /*
 
-   Copyright (c) 2003-2025 Greg Sabino Mullane and others: see the Changes file
+   Copyright (c) 2003-2026 Greg Sabino Mullane and others: see the Changes file
    
    You may distribute under the terms of either the GNU General Public
    License or the Artistic License, as specified in the Perl README file.
@@ -766,7 +766,7 @@ open $newfh, '>', "$file.tmp";
 
 print $newfh qq{$slashstar
 
-   Copyright (c) 2003-2025 Greg Sabino Mullane and others: see the Changes file
+   Copyright (c) 2003-2026 Greg Sabino Mullane and others: see the Changes file
    
    You may distribute under the terms of either the GNU General Public
    License or the Artistic License, as specified in the Perl README file.


### PR DESCRIPTION
Since I noticed that, I thought I could just fix it quickly.