### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# Keep the GitHub Actions used in .github/workflows/* up to date
+# Reference: https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"                  # Root of the repository
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10    # Prevent too many open PRs
+    # Group updates together (newer Dependabot feature)
+    groups:
+      actions:
+        dependency-type: "production"


### PR DESCRIPTION
As discussed in issue #159, this should keep the dependencies of the GitHub Actions workflows up to date.