### PR TITLE
Update git ls-files command in t/99_lint.t to include safe.directory option

### DIFF
--- a/t/99_lint.t
+++ b/t/99_lint.t
@@ -150,7 +150,7 @@ for my $file (sort keys %devfile) {
 }
 
 ## All files in the repo should be mentioned in the README.dev
-my %gitfiles = map { chomp; $_, 1 } qx{git ls-files};
+my %gitfiles = map { chomp; $_, 1 } qx{git -c 'safe.directory=*' ls-files};
 for my $file (sort keys %gitfiles) {
     next if $file =~ /^z_announcements/;
     next if $file =~ /^\.git/;


### PR DESCRIPTION
This PR should fix the following message which appears in [the GitHub Actions CI workflow output](https://github.com/bucardo/dbdpg/actions/runs/22492942684/job/65160057294?pr=150#step:9:57):
```
fatal: detected dubious ownership in repository at '/__w/dbdpg/dbdpg'
To add an exception for this directory, call:

	git config --global --add safe.directory /__w/dbdpg/dbdpg
```