### PR TITLE
Redux: Fix hangup of execution of queries like "COPY TO STDOUT" in asynchronous mode (now with tests)

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5589,6 +5589,9 @@ long pg_db_result (SV *h, imp_dbh_t *imp_dbh)
             imp_dbh->last_result = result;
             imp_dbh->result_clearable = DBDPG_TRUE;
         }
+        if (rows == -1) {
+            break;
+        }
     }
 
     if (imp_sth && imp_sth == imp_dbh->async_sth) {

--- a/t/08async.t
+++ b/t/08async.t
@@ -26,7 +26,7 @@ if (! $dbh_noerr) {
 $dbh_noerr->{RaiseError} = 0;
 $dbh_noerr->{PrintError} = 0;
 
-plan tests => 117;
+plan tests => 128;
 
 isnt ($dbh, undef, 'Connect to database for async testing');
 
@@ -666,6 +666,62 @@ $t=q{sth2 finish succeeds};
 ok ($sth2->finish, $t);
 
 $sth1->finish;
+
+# Test async COPY TO STDOUT: non-blocking do(), polling, result, and data drain
+$t = q{do() with PG_ASYNC on COPY TO STDOUT returns '0E0' immediately (non-blocking)};
+eval {
+    $res = $dbh->do(
+        q{COPY (SELECT * FROM unnest(ARRAY[1,2,3,4,5,6,7,8,9,10]::int[]) as dbd_pg_asynccopytest(a)) TO STDOUT},
+        { pg_async => PG_ASYNC }
+    );
+};
+is ($@, q{}, $t);
+is ($res, '0E0', "$t - result is '0E0' (expected for async COPY TO STDOUT)");
+
+$t = q{Database is in async mode after async COPY do()};
+is ($dbh->{pg_async_status}, 1, $t);
+
+$t = q{pg_ready() becomes true within reasonable time for small async COPY TO STDOUT};
+my $ready = 0;
+for my $i (1..12) {  # up to ~12 seconds max wait
+    if ($dbh->pg_ready) {
+        $ready = 1;
+        last;
+    }
+    sleep 1;
+}
+ok ($ready, $t);
+
+$t = q{pg_result() succeeds after async COPY TO STDOUT completes without error};
+eval {
+    $res = $dbh->pg_result();
+};
+is ($@, q{}, $t);
+
+$t = q{pg_result() after async COPY TO STDOUT returns -1 (rows unknown during COPY)};
+is ($res, -1, $t);
+
+$t = q{We can drain the async COPY TO STDOUT data stream via pg_getcopydata loop};
+my @copied_rows;
+while (1) {
+    my $buf = '';
+    my $status = $dbh->pg_getcopydata($buf);
+    last if !(defined $status && $status >= 0);
+    chomp $buf;
+    push @copied_rows, $buf;
+}
+is (scalar @copied_rows, 10, "$t - received correct number of rows from async COPY TO STDOUT");
+is_deeply (\@copied_rows, [qw(1 2 3 4 5 6 7 8 9 10)], "$t - correct row values from async COPY TO STDOUT");
+
+$t = q{Async status cleared after full COPY drain + pg_result};
+is ($dbh->{pg_async_status}, 0, $t);
+
+# Cleanup / sanity checks
+eval { $dbh->pg_ready(); };
+like ($@, qr{No async|async query}, 'pg_ready fails after COPY TO STDOUT completed and cleared');
+
+eval { $dbh->do('SELECT 1'); };
+is ($@, q{}, 'Normal synchronous query works after async COPY TO STDOUT finished');
 
 cleanup_database($dbh,'test');
 $dbh_noerr->disconnect;


### PR DESCRIPTION
This is an updated version of @true-alex's pull request #101. It is meant to address issue #98.

`$dbh->do("COPY (select * from unnest(ARRAY[1,2,3,4,5,6,7,8]::int[]) as mytable(a)) TO STDOUT", {pg_async => PG_ASYNC});` still hangs with DBD::Pg 3.19.0.

I have applied @true-alex's proposed fix to the latest master branch and added tests to `t/08async.t`.

The proposed fix indeed prevents hanging the process, but I don't think the return value of `$dbh->pg_result()` is correct. Once `$dbh->pg_ready` becomes true after executing `$dbh->do("COPY (select * from unnest(ARRAY[1,2,3,4,5,6,7,8]::int[]) as mytable(a)) TO STDOUT", {pg_async => PG_ASYNC});`, `$dbh->pg_result()` currently returns -1, but I think it should return 0 (the number of rows affected). Am I right about that, @turnstep ?

Marking PR as a draft for now.