### PR TITLE
Handle async prepare correctly in handle_old_async

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5938,6 +5938,8 @@ static int handle_old_async(pTHX_ SV * handle, imp_dbh_t * imp_dbh, const int as
            to be sent & the result dealt with */
         if (async_sth && async_sth->async_status == STH_ASYNC_PREPARE
             && status == PGRES_COMMAND_OK) {
+            ++imp_dbh->prepare_number;
+
             ret = pq_send_prepared_query(aTHX_ imp_dbh, async_sth);
             if (!ret) {
                 TRACE_PQERRORMESSAGE;

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -2552,9 +2552,10 @@ static int pg_st_prepare_statement (pTHX_ SV * sth, imp_sth_t * imp_sth)
         TRACE_PQSENDPREPARE;
         status = PQsendPrepare(imp_dbh->conn, imp_sth->prepare_name, statement, params,
                                imp_sth->PQoids);
-        if (status)
+        if (status) {
             imp_sth->async_status = STH_ASYNC_PREPARE;
-        else {
+            imp_dbh->async_sth = imp_sth;
+        } else {
             status = PGRES_FATAL_ERROR;
             _fatal_sqlstate(aTHX_ imp_dbh);
         }

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5846,6 +5846,7 @@ static int handle_old_async(pTHX_ SV * handle, imp_dbh_t * imp_dbh, const int as
 
             /* Auto-retrieve results for the owning statement instead of discarding */
             if (NULL != async_sth &&
+                STH_ASYNC == async_sth->async_status &&
                 (PGRES_TUPLES_OK == status || PGRES_COMMAND_OK == status)) {
 
                 imp_sth_t *orig_sth = async_sth;

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5845,10 +5845,10 @@ static int handle_old_async(pTHX_ SV * handle, imp_dbh_t * imp_dbh, const int as
             status = _sqlstate(aTHX_ imp_dbh, result);
 
             /* Auto-retrieve results for the owning statement instead of discarding */
-            if (NULL != imp_dbh->async_sth &&
+            if (NULL != async_sth &&
                 (PGRES_TUPLES_OK == status || PGRES_COMMAND_OK == status)) {
 
-                imp_sth_t *orig_sth = imp_dbh->async_sth;
+                imp_sth_t *orig_sth = async_sth;
 
                 if (orig_sth->result) {
                     TRACE_PQCLEAR;
@@ -5880,12 +5880,12 @@ static int handle_old_async(pTHX_ SV * handle, imp_dbh_t * imp_dbh, const int as
                 result = NULL;
             }
             /* Auto-retrieve error: store for the owning statement */
-            else if (NULL != imp_dbh->async_sth &&
+            else if (NULL != async_sth &&
                      PGRES_EMPTY_QUERY != status &&
                      PGRES_COMMAND_OK != status &&
                      PGRES_TUPLES_OK != status) {
 
-                imp_sth_t *orig_sth = imp_dbh->async_sth;
+                imp_sth_t *orig_sth = async_sth;
 
                 if (orig_sth->result) {
                     TRACE_PQCLEAR;

--- a/dbdimp.c
+++ b/dbdimp.c
@@ -5844,7 +5844,7 @@ static int handle_old_async(pTHX_ SV * handle, imp_dbh_t * imp_dbh, const int as
             status = _sqlstate(aTHX_ imp_dbh, result);
 
             /* Auto-retrieve results for the owning statement instead of discarding */
-            if ((asyncflag & PG_OLDQUERY_WAIT) && NULL != imp_dbh->async_sth &&
+            if (NULL != imp_dbh->async_sth &&
                 (PGRES_TUPLES_OK == status || PGRES_COMMAND_OK == status)) {
 
                 imp_sth_t *orig_sth = imp_dbh->async_sth;
@@ -5879,7 +5879,7 @@ static int handle_old_async(pTHX_ SV * handle, imp_dbh_t * imp_dbh, const int as
                 result = NULL;
             }
             /* Auto-retrieve error: store for the owning statement */
-            else if ((asyncflag & PG_OLDQUERY_WAIT) && NULL != imp_dbh->async_sth &&
+            else if (NULL != imp_dbh->async_sth &&
                      PGRES_EMPTY_QUERY != status &&
                      PGRES_COMMAND_OK != status &&
                      PGRES_TUPLES_OK != status) {

--- a/t/08async.t
+++ b/t/08async.t
@@ -398,7 +398,7 @@ $t=q{Database method pg_result returns correct result after execute};
 is ($res, 2, $t);
 
 {
-    my ($sth0, $sth1);
+    my ($sth0, $sth1, $old_switch);
 
     #
     # Test that handle_old_async deals correctly with async prepares.
@@ -411,6 +411,7 @@ is ($res, 2, $t);
     $sth0= $dbh->prepare('select * from dbd_pg_test5 where id = ?', { pg_async => PG_ASYNC, pg_prepare_now => 1 });
 
     # Tell execute that it should prepare on first execution.
+    $old_switch = $$dbh{switch_prepared};
     $$dbh{pg_switch_prepared} = 1;
 
     # Create async statement w/o prepare.
@@ -432,6 +433,8 @@ is ($res, 2, $t);
         $dbh->pg_result();
     };
     is ($@, q{}, $t);
+
+    $$dbh{pg_switch_prepared} = $old_switch;
 }
 
 $dbh->do('DROP TABLE dbd_pg_test5');

--- a/t/08async.t
+++ b/t/08async.t
@@ -26,7 +26,7 @@ if (! $dbh_noerr) {
 $dbh_noerr->{RaiseError} = 0;
 $dbh_noerr->{PrintError} = 0;
 
-plan tests => 116;
+plan tests => 117;
 
 isnt ($dbh, undef, 'Connect to database for async testing');
 
@@ -396,6 +396,43 @@ eval {
 is ($@, q{}, $t);
 $t=q{Database method pg_result returns correct result after execute};
 is ($res, 2, $t);
+
+{
+    my ($sth0, $sth1);
+
+    #
+    # Test that handle_old_async deals correctly with async prepares.
+    # See https://github.com/bucardo/dbdpg/pull/142#issuecomment-4260460925
+    #
+
+    $t=q{Pending async prepare handled correctly by handle_old_async};
+
+    # Start an async prepare.
+    $sth0= $dbh->prepare('select * from dbd_pg_test5 where id = ?', { pg_async => PG_ASYNC, pg_prepare_now => 1 });
+
+    # Tell execute that it should prepare on first execution.
+    $$dbh{pg_switch_prepared} = 1;
+
+    # Create async statement w/o prepare.
+    $sth1 = $dbh->prepare('select * from dbd_pg_test5 where t = ?', { pg_async => PG_ASYNC | PG_OLDQUERY_WAIT});
+
+    # Execute. This will call handle_old_async to wait for the result
+    # of the previous async prepare & query and then start a second
+    # async prepare.
+    $sth1->execute(2);
+    eval {
+        # Wait for result.
+        # Without the fix, this will abort with
+        #
+        #  prepared statement "dbdpg_p3993_X" already exists
+        #
+        # as first and second prepare will have used the same
+        # prepare_number because handle_old_async didn't increment
+        # it.
+        $dbh->pg_result();
+    };
+    is ($@, q{}, $t);
+}
 
 $dbh->do('DROP TABLE dbd_pg_test5');
 

--- a/t/08async.t
+++ b/t/08async.t
@@ -408,11 +408,11 @@ is ($res, 2, $t);
     $t=q{Pending async prepare handled correctly by handle_old_async};
 
     # Start an async prepare.
-    $sth0= $dbh->prepare('select * from dbd_pg_test5 where id = ?', { pg_async => PG_ASYNC, pg_prepare_now => 1 });
+    $sth0 = $dbh->prepare('select * from dbd_pg_test5 where id = ?', { pg_async => PG_ASYNC, pg_prepare_now => 1 });
 
     # Tell execute that it should prepare on first execution.
     $old_switch = $$dbh{switch_prepared};
-    $$dbh{pg_switch_prepared} = 1;
+    $dbh->{pg_switch_prepared} = 1;
 
     # Create async statement w/o prepare.
     $sth1 = $dbh->prepare('select * from dbd_pg_test5 where t = ?', { pg_async => PG_ASYNC | PG_OLDQUERY_WAIT});
@@ -434,7 +434,7 @@ is ($res, 2, $t);
     };
     is ($@, q{}, $t);
 
-    $$dbh{pg_switch_prepared} = $old_switch;
+    $dbh->{pg_switch_prepared} = $old_switch;
 }
 
 $dbh->do('DROP TABLE dbd_pg_test5');


### PR DESCRIPTION
When `handle_old_async` is invoked in wait mode and encounters a successful async prepare, it won't increment `imp_dbh->prepare_number` and hence, the next server-side prepared statement which will be created afterwards will cause a name collision. 

This pull request really fixes three related issues:

- `pg_st_prepare_statement` doesn't set `imp_dbh->async_sth` after starting an async prepare
- the code to auto-retrieve results in `handle_old_async` incorrectly treats the result of a prior async prepare as query result despite the query wasn't executed yet
- the code supposed to deal with a successful async prepare in `handle_old_async` fails to increment `imp_dbh->prepare_number` and thus, causes the abovementioned name collision

Further, it does some minor cleanups to simplify the `handle_old_async` code:

- remove two redundant `asyncflag & PG_OLDQUERY_WAIT` tests from code which only runs if this condition was true
- use existing `async_sth` variable (initialized with `imp_dbh->async_sth`) instead of repeating `imp_sth->async_sth`

Lastly, it adds a test case for catching the name collision which will occur of the `++imp_dbh->prepare_number` in `handle_old_async` isn't there (aka commented out).
