### PR TITLE
Fix macOS builds

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -14,7 +14,6 @@ my $sep;
 BEGIN {
     my %seplist = (
                MacOS   => ':',
-               darwin  => ':',
                MSWin32 => '\\',
                os2     => '\\',
                VMS     => '\\',


### PR DESCRIPTION
This PR fixes builds/installs on macOS. macOS (Darwin) uses `/` as a directory separator, not `:`. The last Mac operating system which used `:` as a directory separator was MacOS 9.2.2, released in 2001.

Report: https://github.com/bucardo/dbdpg/discussions/189#discussioncomment-16781817
Co-authored-by: Ed Sabol
Co-authored-by: Éric Cholet
Reported-by: Éric Cholet