### PR TITLE
Testing: move plan declaration after the skip_all calls

### DIFF
--- a/t/03dbmethod.t
+++ b/t/03dbmethod.t
@@ -17,7 +17,6 @@ use strict;
 use warnings;
 use lib 'blib/lib', 'blib/arch', 't';
 use Test::More;
-plan tests => 702;
 use Config;
 use DBI     ':sql_types';
 use DBD::Pg ':pg_types';
@@ -31,6 +30,7 @@ my $dbh = connect_database();
 if (! $dbh) {
     plan skip_all => 'Connection to database failed, cannot continue testing';
 }
+plan tests => 702;
 
 my $superuser = is_super();
 

--- a/t/10_pg_error_field.t
+++ b/t/10_pg_error_field.t
@@ -7,7 +7,6 @@ use strict;
 use warnings;
 use lib 'blib/lib', 'blib/arch', 't';
 use Test::More;
-plan tests => 5;
 require 'dbdpg_test_setup.pl';
 select(($|=1,select(STDERR),$|=1)[1]);
 
@@ -16,6 +15,7 @@ my $dbh = connect_database();
 if (! $dbh) {
     plan skip_all => 'Connection to database failed, cannot continue testing';
 }
+plan tests => 5;
 
 my $t='Connect to database for pg_error_field testing';
 isnt ($dbh, undef, $t);

--- a/t/30unicode.t
+++ b/t/30unicode.t
@@ -13,7 +13,6 @@ use charnames ':full';
 use Encode qw(encode_utf8);
 use Data::Dumper;
 use Test::More;
-plan tests => 2;
 use open qw/ :std :encoding(utf8) /;
 require 'dbdpg_test_setup.pl';
 select(($|=1,select(STDERR),$|=1)[1]);
@@ -23,6 +22,7 @@ my $dbh = connect_database();
 if (! $dbh) {
     plan skip_all => 'Connection to database failed, cannot continue testing';
 }
+plan tests => 2;
 
 isnt ($dbh, undef, 'Connect to database for unicode testing');
 

--- a/t/99_lint.t
+++ b/t/99_lint.t
@@ -23,8 +23,6 @@ if (! -e $file) {
     exit;
 }
 
-plan tests => 11;
-
 open my $fh, '<', $file or die "Could not open $file: $!\n";
 @perlfiles = map { chomp; $_ } grep { /\.pm$/ or /\.t$/ } <$fh>;
 seek $fh ,0, 0;
@@ -46,6 +44,8 @@ push @testfiles => map { chomp; $_ } grep { m{t/.*\.t} } <$fh>;
 seek $fh, 0, 0;
 push @perlfiles => map { chomp; $_ } grep { m{t/.*\.t} } <$fh>;
 close $fh;
+
+plan tests => 11;
 
 ##
 ## Ensure all test names are unique

--- a/t/99_perlcritic.t
+++ b/t/99_perlcritic.t
@@ -8,7 +8,6 @@ use 5.008001;
 use strict;
 use warnings;
 use Test::More;
-plan tests => 29;
 use Data::Dumper;
 
 if (! $ENV{AUTHOR_TESTING}) {
@@ -20,6 +19,7 @@ elsif (!eval { require Perl::Critic; 1 }) {
 elsif ($Perl::Critic::VERSION < 0.23) {
     plan skip_all => 'Perl::Critic must be version 0.23 or higher';
 }
+plan tests => 29;
 
 $ENV{LANG} = 'C';
 opendir my $dir, 't' or die qq{Could not open directory 't': $!\n};

--- a/t/99_spellcheck.t
+++ b/t/99_spellcheck.t
@@ -10,7 +10,6 @@ use 5.008001;
 use strict;
 use warnings;
 use Test::More;
-plan tests => 65;
 use utf8; ## no critic (TooMuchCode::ProhibitUnnecessaryUTF8Pragma)
 select(($|=1,select(STDERR),$|=1)[1]);
 
@@ -23,6 +22,8 @@ elsif (!eval { require Text::SpellChecker; 1 }) {
     plan skip_all => 'Could not find Text::SpellChecker'; ## nospellcheck
 }
 else {
+    plan tests => 65;
+
     opendir my $dir, 't' or die qq{Could not open directory 't': $!\n};
     @testfiles = map { "t/$_" } grep { ! /spellcheck|lint/ } grep { /^.+\.(t|pl)$/ } readdir $dir;
     rewinddir $dir;


### PR DESCRIPTION
Test plan specific target declaration needs to be after any skip_all calls.

Resolves https://github.com/bucardo/dbdpg/issues/203
