### PR TITLE
Support compiling with versions of GCC < 5

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -193,6 +193,15 @@ my $defines = " -DPGLIBVERSION=$serverversion -DPGDEFPORT=$defaultport";
 if ($Config{ivsize} >= 8 && $serverversion >= 90300) {
     $defines .= ' -DHAS64BITLO ';
 }
+
+# GCC versions < 5 need -std=gnu99 to support for-loop local declarations
+if ($Config{gccversion} && $Config{gccversion} =~ /^(\d+)\./) {
+    my $gcc_major_version = $1;
+    if ($gcc_major_version < 5) {
+        $defines .= ' -std=gnu99 ';
+    }
+}
+
 my $comp_opts = $Config{q{ccflags}} . $defines;
 
 if ($ENV{DBDPG_GCCDEBUG}) {


### PR DESCRIPTION
I was looking through the cpantesters reports, and [this Perl 5.24.0 build](https://www.cpantesters.org/cpan/report/5901671c-9e72-11f1-b690-edda6d8775ea) failed because it's using gcc 4.7.2 and recent commits added for-loop local declarations in some for loop initializers (which gcc didn't start supporting by default until 5.0.0).
```
dbdimp.c: In function 'ph_array_destroy':
dbdimp.c:162:5: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c:162:5: note: use option -std=c99 or -std=gnu99 to compile your code
dbdimp.c: In function 'seg_array_destroy':
dbdimp.c:210:5: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c: In function 'pg_st_FETCH_attrib':
dbdimp.c:1344:13: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c:1370:13: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c:1403:13: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c:1425:13: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c:1433:13: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c: In function 'pg_st_split_statement':
dbdimp.c:2412:13: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c:2490:9: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c:2498:13: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c:2539:9: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c:2546:13: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c: In function 'pg_st_prepare_statement':
dbdimp.c:2594:5: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c:2609:9: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c: In function 'pg_bind_ph':
dbdimp.c:2716:9: error: 'for' loop initial declarations are only allowed in C99 mode
dbdimp.c: In function 'pg_st_fetch':
dbdimp.c:4103:9: error: 'for' loop initial declarations are only allowed in C99 mode
make: *** [dbdimp.o] Error 1
```
This merge request adds `-std=gnu99` to builds with GCC major versions less than 5.