### PR TITLE
dbdpg_test_setup.pl: Avoid using getpwent and compare uid values instead

### DIFF
--- a/t/dbdpg_test_setup.pl
+++ b/t/dbdpg_test_setup.pl
@@ -414,8 +414,9 @@ version: $version
             my @userlist = (qw/postgres postgresql pgsql _postgres/);
 
             ## Start with whoever owns this file, unless it's us
-            my $username = getpwuid ((stat($0))[4]);
-            unshift @userlist, $username if defined $username and $username ne getpwent;
+            my $file_owner_uid = (stat($0))[4];
+            my $username = defined $file_owner_uid ? getpwuid($file_owner_uid) : undef;
+            unshift @userlist, $username if defined $username and $file_owner_uid != $<;
 
             my %doneuser;
             for (@userlist) {


### PR DESCRIPTION
`getpwent()` is weird. It's actually an iterator, so it will not return the correct username after the first call. And it returns an array when it's not in scalar context. I think this part of `dbdpg_test_setup.pl` would be more robust if it just compared uid values instead.