### PR TITLE
dbdpg_test_setup.pl: Make port discovery more robust

### DIFF
--- a/t/dbdpg_test_setup.pl
+++ b/t/dbdpg_test_setup.pl
@@ -497,15 +497,15 @@ version: $version
         $info = '';
         my $evalok = 0;
         eval {
-            $info = $^O =~ /Win32/ ? qx{netstat -anp TCP}: qx{ss -QanO 2>&1};
+            $info = $^O =~ /(?:Win32|darwin|bsd|dragonfly)/ ? qx{netstat -anp TCP 2>&1} : qx{ss -anO 2>&1};
             $evalok = 1;
         };
         if (!$evalok or ! defined $info) {
-            Test::More::diag "ss call to determine open port failed, trying port $testport\n";
+            Test::More::diag "Unable to determine open port, trying port $testport\n";
         }
         else {
             {
-                last if $info !~ /:$testport /m;
+                last if $info !~ /^\s*tcp.+?(?:\d+\.\d+\.\d+\.\d+|\*)[:.]$testport\s/im;
                 last if ++$testport > $TEST_PORT_MAX;
                 redo;
             }


### PR DESCRIPTION
This PR makes port discovery more robust in `dbdpg_test_setup.pl`. `ss` doesn't exist on macOS and *BSD systems. We need to use `netstat` on such systems. Also, `netstat` on macOS and *BSD systems (but not on Linux, apparently) puts a period (instead of a colon) before the port number. Finally, Google Gemini insists there can be a tab (or possibly nothing) after the port number (instead of a space) in some cases.