### PR TITLE
Cleanup the data_sources function and its tests.

### DIFF
--- a/.perlcriticrc
+++ b/.perlcriticrc
@@ -3,7 +3,7 @@ profile-strictness = quiet
 exclude = Mardem
 
 [Documentation::PodSpelling]
-stop_words = ActiveKids afterwards arrayref arrayrefs async attr autocommit AutoCommit AutoInactiveDestroy backend bitmask bool boolean Bunce bytea CachedKids cancelled ChildHandles ChopBlanks CompatMode CursorName datatype Datatype datatypes dbd DBD dbdpg dbh DBI deallocation deallocated dev dr DSN enum ErrCount errstr fd FetchHashKeyName filename func getfd getline github HandleError HandleSetErr hashref hashrefs InactiveDestroy JSON largeobject len libpq LongReadLen LongTruncOk lseg Mergl Momjian Mullane nullable NULLABLE Oid OID onwards param ParamTypes ParamValues perl Perlish PgBouncer pgbuiltin pgend pglibpq pglogin pgprefix pgquote PGSERVICE PGSERVICEFILE pgsql pgstart PGSYSCONFDIR PID Postgres PostgreSQL PQexecParams PQexecPrepared PQsetnonblocking PrintError PrintWarn pseudotype RaiseError README ReadOnly RowCache RowCacheSize RowsInCache runtime Sabino savepoint savepoints Savepoints schemas ShowErrorStatement SQL SQLSTATE SSL sslmode sslrootcert STDERR STDIN STDOUT stringify subdirectory tablename tablespace tablespaces TaintIn TaintOut TraceLevel tuple typename undef username Username UTF varchar
+stop_words = ActiveKids afterwards arrayref arrayrefs async attr autocommit AutoCommit AutoInactiveDestroy backend bitmask bool boolean Bunce bytea CachedKids cancelled ChildHandles ChopBlanks CompatMode CursorName datatype Datatype datatypes dbd DBD dbdpg dbh DBI deallocation deallocated dev dr DSN enum ErrCount errstr fd FetchHashKeyName filename func getfd getline github HandleError HandleSetErr hashref hashrefs InactiveDestroy JSON largeobject len libpq LongReadLen LongTruncOk lseg Mergl Momjian Mullane nullable NULLABLE Oid OID onwards param ParamTypes ParamValues perl Perlish PgBouncer pgbuiltin pgend pglibpq pglogin pgprefix pgquote PGSERVICE PGSERVICEFILE pgsql pgstart PGSYSCONFDIR PID postgres Postgres PostgreSQL PQexecParams PQexecPrepared PQsetnonblocking PrintError PrintWarn pseudotype RaiseError README ReadOnly RowCache RowCacheSize RowsInCache runtime Sabino savepoint savepoints Savepoints schemas ShowErrorStatement SQL SQLSTATE SSL sslmode sslrootcert STDERR STDIN STDOUT stringify subdirectory tablename tablespace tablespaces TaintIn TaintOut TraceLevel tuple typename undef username Username UTF varchar
 
 [-Bangs::ProhibitBitwiseOperators]
 [-Bangs::ProhibitCommentedOutCode]
@@ -129,6 +129,7 @@ stop_words = ActiveKids afterwards arrayref arrayrefs async attr autocommit Auto
 [-ValuesAndExpressions::RequireNumberSeparators]
 [-ValuesAndExpressions::RequireNumericVersion]
 [-ValuesAndExpressions::RestrictLongStrings]
+[-Variables::ProhibitAugmentedAssignmentInDeclaration]
 [-Variables::ProhibitConditionalDeclarations]
 [-Variables::ProhibitLocalVars]
 [-Variables::ProhibitPackageVars]

--- a/Pg.pm
+++ b/Pg.pm
@@ -1895,7 +1895,9 @@ Implemented by DBI, no driver-specific impact.
 =head3 B<data_sources>
 
   @data_sources = $dbh->data_sources($attr);
+  @data_sources = $dbh->data_sources(\%attr);
   @data_sources = DBI->data_sources('Pg', $attr);
+  @data_sources = DBI->data_sources('Pg', \%attr);
 
 Returns a list of available databases as DBI connection strings.
 

--- a/Pg.pm
+++ b/Pg.pm
@@ -215,22 +215,43 @@ use 5.008001;
 
     use strict;
 
-    ## Returns an array of formatted database names from the pg_database table
+    ## Returns a list of formatted database names from the pg_database table
+    ## Each is prefixed with 'dbi:Pg:dbname=' making it suitable to pass to connect()
+    ## This function can be called via DBI or $dbh
     sub data_sources {
 
         my $drh = shift;
         my $extra_conninfo = shift || '';
-        $extra_conninfo =~ s/^([^;])/;$1/;
+        my $ref = ref $extra_conninfo;
+
+        if ($ref eq 'HASH') {
+            if (%$extra_conninfo) {
+                $extra_conninfo = ';' . join ';' => map { "$_=$extra_conninfo->{$_}" } sort keys %$extra_conninfo;
+            }
+            else {
+                $extra_conninfo = '';
+            }
+        }
+        elsif ($ref eq '') {
+            $extra_conninfo = '' if $extra_conninfo eq 'Pg';
+            $extra_conninfo =~ s/^([^;])/;$1/;
+        }
+        else {
+            die "data_sources(): unsupported argument type $ref: should be string or a hashref\n";
+        }
 
         my $connstring = 'dbname=postgres';
         if ($ENV{DBI_DSN}) {
-            ($connstring = $ENV{DBI_DSN}) =~ s/dbi:Pg://i;
+            ($connstring = $ENV{DBI_DSN}) =~ s/\s*dbi:Pg://ig;
         }
+        $connstring =~ s/^;//;
 
-        my $dbh = DBD::Pg::dr::connect($drh, $connstring) or die 'Could not connect to the database';
+        my $dbh = DBD::Pg::dr::connect($drh, $connstring)
+          or die "Could not connect to the database: $DBI::errstr";
 
         my @sources;
         eval {
+            ## The quote_ident function will quote database names with semicolons inside of them
             my $SQL = 'SELECT pg_catalog.quote_ident(datname) FROM pg_catalog.pg_database ORDER BY 1';
             my $sth = $dbh->prepare($SQL) or die $dbh->errstr;
             $sth->execute() or die $sth->errstr;
@@ -1873,18 +1894,20 @@ Implemented by DBI, no driver-specific impact.
 
 =head3 B<data_sources>
 
-  @data_sources = $dbh->data_sources('Pg', \%attr);
-  @data_sources = DBI->data_sources('Pg', \%attr);
+  @data_sources = $dbh->data_sources($attr);
+  @data_sources = DBI->data_sources('Pg', $attr);
 
 Returns a list of available databases as DBI connection strings.
 
-Unless the environment variable C<DBI_DSN> is set, a connection will be attempted
-to the database C<postgres>. The normal connection environment variables also apply,
-such as C<PGHOST>, C<PGPORT>, C<DBI_USER>, C<DBI_PASS>, and C<PGSERVICE>.
+The first argument must be 'Pg' when using the DBI->data_sources form.
 
-The first argument should always be 'Pg'
+The $attr argument gives options to append to the resulting connection strings.
+It can be a string or a hashref.
 
-The second argument is a list of options to append to the resulting connection strings.
+This connects to the database named 'postgres' by default. To use another,
+specify it in the DBI_DSN environment variable, e.g.:
+
+  { $ENV{DBI_DSN} = 'dbname=mydb'; @data_sources = $dbh->data_sources(); }
 
 For example, to specify an alternate port and host:
 

--- a/t/04misc.t
+++ b/t/04misc.t
@@ -23,7 +23,7 @@ END { defined $filename and -e $filename and unlink $filename; }
 if (! $dbh) {
     plan skip_all => 'Connection to database failed, cannot continue testing';
 }
-plan tests => 100;
+plan tests => 117;
 
 my $superuser = is_super();
 
@@ -457,63 +457,107 @@ dbdpg: Begin _sqlstate
 # Test of the "data_sources" method
 #
 
-$t='Database handle method data_sources() returns an entry for template0';
-my @sources = $dbh->data_sources('Pg');
-my $expected = qr{\bdbi:Pg:dbname=template0\b};
-like ((join ' ' => @sources), $expected, $t);
+my $expected = qr{\bdbi:Pg:dbname=template0(?:$| )};
+my $expected_port = qr{\bdbi:Pg:dbname=template0;port=1234(?:$| )};
+my $expected_hostport = qr{\bdbi:Pg:dbname=template0;host=foo;port=1234(?:$| )};
+my @sources;
+my $dsn = defined $ENV{DBI_DSN} ? $ENV{DBI_DSN} : '';
 
-$t='DBI method data_sources() returns an entry for template0';
+$t=q{DBI method data_sources() works when first arg is 'Pg'};
 @sources = DBI->data_sources('Pg');
 like ((join ' ' => @sources), $expected, $t);
 
-$t='Database handle method data_sources() returns an entry for template0 when called with no arg';
-eval {
-    @sources = $dbh->data_sources();
-};
+$t=q{DBI method data_sources() works when first arg is 'Pg' and second arg is set};
+@sources = DBI->data_sources('Pg', 'port=1234');
+like ((join ' ' => @sources), $expected_port, $t);
+
+$t='DBI method data_sources() throws an error when first arg is "pg"';
+eval { @sources = DBI->data_sources('pg'); };
+like ($@, qr/install_driver/, $t);
+
+$t='DBI method data_sources() throws an error when DBI_DSN is invalid';
+eval { local $ENV{DBI_DSN} = 'foo'; @sources = DBI->data_sources('Pg'); };
+like ($@, qr/Could not connect/, $t);
+
+$t='DBI method data_sources() works when DBI_DSN is valid';
+{ local $ENV{DBI_DSN} .= "$dsn;sslmode=allow"; @sources = DBI->data_sources('Pg'); }
 like ((join ' ' => @sources), $expected, $t);
 
-$t='DBI method data_sources() returns an error when called with no arg';
-eval {
-    local $ENV{DBI_DRIVER} = '';
-    @sources = DBI->data_sources();
-};
+$t=q{DBI method data_sources() removes 'dbi:Pg:' from DBI_DSN};
+{ local $ENV{DBI_DSN} .= "$dsn;dbi:Pg:sslmode=allow"; @sources = DBI->data_sources('Pg'); }
+like ((join ' ' => @sources), $expected, $t);
+
+$t=q{DBI method data_sources() removes '  DBI:PG:' from DBI_DSN};
+{ local $ENV{DBI_DSN} .= "$dsn;  DBI:PG:sslmode=allow"; @sources = DBI->data_sources('Pg'); }
+like ((join ' ' => @sources), $expected, $t);
+
+$t='DBI method data_sources() throws an error when no args';
+eval { local $ENV{DBI_DRIVER}; @sources = DBI->data_sources(); };
 like ($@, qr/usage:/, $t);
 
-$t='DBI method data_sources() returns correct DSN when second arg is a port';
-my $port = 12345;
-@sources = DBI->data_sources('Pg',"port=$port");
-like ((join ' ' => @sources), qr{dbi:Pg:dbname=template0;port=$port}, $t);
+$t='DBI method data_sources() throws an error when no args and DBI_DRIVER is empty';
+eval { local $ENV{DBI_DRIVER} = ''; @sources = DBI->data_sources(); };
+like ($@, qr/usage:/, $t);
 
-$t='DBI method data_sources() returns correct DSN when second arg is a port with a leading semicolon';
-@sources = DBI->data_sources('Pg',";port=$port");
-like ((join ' ' => @sources), qr{dbi:Pg:dbname=template0;port=$port}, $t);
+$t=q{DBI method data_sources() throws an error when no args and DBI_DRIVER is 'pg'};
+eval { local $ENV{DBI_DRIVER} = 'pg'; @sources = DBI->data_sources(); };
+like ($@, qr/install_driver/, $t);
 
-SKIP: {
+$t=q{DBI method data_sources() works when no args and DBI_DRIVER is 'Pg'};
+{ local $ENV{DBI_DRIVER} = 'Pg'; @sources = DBI->data_sources(); }
+like ((join ' ' => @sources), $expected, $t);
 
-    $t='DBI method data_sources() handles database names with spaces';
-    my $test_db_name = 'dbdpg space test';
+$t=q{DBI method data_sources() works when first arg is empty string and DBI_DRIVER is 'Pg'};
+{ local $ENV{DBI_DRIVER} = 'Pg'; @sources = DBI->data_sources(''); }
+like ((join ' ' => @sources), $expected, $t);
 
-    if (! grep { /\b$test_db_name\b/ } @sources) {
-        eval {
-            $dbh->{AutoCommit} = 1;
-            $dbh->do(qq{CREATE DATABASE "$test_db_name" TEMPLATE template0});
-        };
-        if ($@) {
-            skip (qq{Could not create database "$test_db_name": $@}, 1);
-        }
-    }
+$t=q{DBI method data_sources() works when first arg is undef, second arg is set, and DBI_DRIVER is 'Pg'};
+{ local $ENV{DBI_DRIVER} = 'Pg'; @sources = DBI->data_sources(undef, 'port=1234'); }
+like ((join ' ' => @sources), $expected_port, $t);
 
-    @sources = DBI->data_sources('Pg',"port=$port");
+$t=q{DBI method data_sources() works when first arg is empty string, second arg is set, and DBI_DRIVER is 'Pg'};
+{ local $ENV{DBI_DRIVER} = 'Pg'; @sources = DBI->data_sources('', 'port=1234'); }
+like ((join ' ' => @sources), $expected_port, $t);
 
-    like ((join ' ' => @sources), qr{dbi:Pg:dbname="$test_db_name";port=$port}, $t);
+$t=q{DBI method data_sources() handles leading semicolon from second arg};
+@sources = DBI->data_sources('Pg', ';port=1234');
+like ((join ' ' => @sources), $expected_port, $t);
 
-    eval {
-        $dbh->{AutoCommit} = 1;
-        $dbh->do(qq{DROP DATABASE "$test_db_name"});
-    };
-    $@ and diag "Unable to drop database $test_db_name: $@";
+$t=q{DBI method data_sources() works when second arg is a single item hashref};
+@sources = DBI->data_sources('Pg', {port => 1234});
+like ((join ' ' => @sources), $expected_port, $t);
 
-}
+$t=q{DBI method data_sources() works when second arg is a multi item hashref};
+@sources = DBI->data_sources('Pg', {host => 'foo', port => 1234});
+like ((join ' ' => @sources), $expected_hostport, $t);
+
+$t=q{DBI method data_sources() works when second arg is an empty hashref};
+@sources = DBI->data_sources('Pg', {});
+like ((join ' ' => @sources), $expected, $t);
+
+$t=q{DBI method data_sources() throws an error when second arg is an arrayref};
+eval { @sources = DBI->data_sources('Pg', ['port', 1234]); };
+like ($@, qr/hashref/, $t);
+
+$t=q{Database handle method data_sources() works when first arg is 'Pg'};
+@sources = $dbh->data_sources('Pg');
+like ((join ' ' => @sources), $expected, $t);
+
+$t=q{Database handle method data_sources() throws an error when more than one argument given};
+eval { @sources = $dbh->data_sources('Pg', 'port=1234'); };
+like ($@, qr/\Qhandle + 2/, $t);
+
+$t='Database handle method data_sources() works when no args';
+{ local $ENV{DBI_DRIVER}; @sources = $dbh->data_sources(); }
+like ((join ' ' => @sources), $expected, $t);
+
+$t=q{Database handle method data_sources() works when no args and DBI_DRIVER is 'pg'};
+{ local $ENV{DBI_DRIVER} = 'pg'; @sources = $dbh->data_sources(); }
+like ((join ' ' => @sources), $expected, $t);
+
+$t=q{Database handle method data_sources() works when first arg is set};
+@sources = $dbh->data_sources('port=1234');
+like ((join ' ' => @sources), $expected_port, $t);
 
 #
 # Test the use of $DBDPG_DEFAULT


### PR DESCRIPTION
Allow the arg to be a string or a hashref.

Filter out lone 'Pg' to let DBI and $dbh calls work identically.

Add 'postgres' to the list of perlcritic stopwords (how was that not already there!)