### PR TITLE
Check if attrs is a hash ref before dereferencing it

### DIFF
--- a/dbdimp.c
+++ b/dbdimp.c
@@ -267,6 +267,8 @@ static int want_async_connect(pTHX_ SV *attrs)
 
     return
         attrs
+        && SvROK(attrs)
+        && SvTYPE(SvRV(attrs)) == SVt_PVHV
         && (psv = hv_fetchs((HV *)SvRV(attrs), "pg_async_connect", 0))
         && (sv = *psv)
         && SvTRUE(sv);


### PR DESCRIPTION
Not doing so can lead to segfaults.

See also https://github.com/Perl/perl5/issues/24682